### PR TITLE
활동 히스토리 & 마이 페이지 기능 구현

### DIFF
--- a/src/main/generated/com/project/singk/domain/activity/infrastructure/QActivityHistoryEntity.java
+++ b/src/main/generated/com/project/singk/domain/activity/infrastructure/QActivityHistoryEntity.java
@@ -1,0 +1,63 @@
+package com.project.singk.domain.activity.infrastructure;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QActivityHistoryEntity is a Querydsl query type for ActivityHistoryEntity
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QActivityHistoryEntity extends EntityPathBase<ActivityHistoryEntity> {
+
+    private static final long serialVersionUID = 511365862L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QActivityHistoryEntity activityHistoryEntity = new QActivityHistoryEntity("activityHistoryEntity");
+
+    public final com.project.singk.global.domain.QBaseTimeEntity _super = new com.project.singk.global.domain.QBaseTimeEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.project.singk.domain.member.infrastructure.QMemberEntity member;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final NumberPath<Integer> score = createNumber("score", Integer.class);
+
+    public final EnumPath<com.project.singk.domain.activity.domain.ActivityType> type = createEnum("type", com.project.singk.domain.activity.domain.ActivityType.class);
+
+    public QActivityHistoryEntity(String variable) {
+        this(ActivityHistoryEntity.class, forVariable(variable), INITS);
+    }
+
+    public QActivityHistoryEntity(Path<? extends ActivityHistoryEntity> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QActivityHistoryEntity(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QActivityHistoryEntity(PathMetadata metadata, PathInits inits) {
+        this(ActivityHistoryEntity.class, metadata, inits);
+    }
+
+    public QActivityHistoryEntity(Class<? extends ActivityHistoryEntity> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new com.project.singk.domain.member.infrastructure.QMemberEntity(forProperty("member"), inits.get("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/project/singk/domain/member/infrastructure/QMemberEntity.java
+++ b/src/main/generated/com/project/singk/domain/member/infrastructure/QMemberEntity.java
@@ -7,6 +7,7 @@ import com.querydsl.core.types.dsl.*;
 import com.querydsl.core.types.PathMetadata;
 import javax.annotation.processing.Generated;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
 
 
 /**
@@ -16,6 +17,8 @@ import com.querydsl.core.types.Path;
 public class QMemberEntity extends EntityPathBase<MemberEntity> {
 
     private static final long serialVersionUID = 835879882L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
 
     public static final QMemberEntity memberEntity = new QMemberEntity("memberEntity");
 
@@ -45,16 +48,27 @@ public class QMemberEntity extends EntityPathBase<MemberEntity> {
 
     public final EnumPath<com.project.singk.domain.member.domain.Role> role = createEnum("role", com.project.singk.domain.member.domain.Role.class);
 
+    public final QMemberStatisticsEntity statistics;
+
     public QMemberEntity(String variable) {
-        super(MemberEntity.class, forVariable(variable));
+        this(MemberEntity.class, forVariable(variable), INITS);
     }
 
     public QMemberEntity(Path<? extends MemberEntity> path) {
-        super(path.getType(), path.getMetadata());
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
     }
 
     public QMemberEntity(PathMetadata metadata) {
-        super(MemberEntity.class, metadata);
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMemberEntity(PathMetadata metadata, PathInits inits) {
+        this(MemberEntity.class, metadata, inits);
+    }
+
+    public QMemberEntity(Class<? extends MemberEntity> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.statistics = inits.isInitialized("statistics") ? new QMemberStatisticsEntity(forProperty("statistics")) : null;
     }
 
 }

--- a/src/main/generated/com/project/singk/domain/member/infrastructure/QMemberStatisticsEntity.java
+++ b/src/main/generated/com/project/singk/domain/member/infrastructure/QMemberStatisticsEntity.java
@@ -1,0 +1,51 @@
+package com.project.singk.domain.member.infrastructure;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QMemberStatisticsEntity is a Querydsl query type for MemberStatisticsEntity
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMemberStatisticsEntity extends EntityPathBase<MemberStatisticsEntity> {
+
+    private static final long serialVersionUID = 526910989L;
+
+    public static final QMemberStatisticsEntity memberStatisticsEntity = new QMemberStatisticsEntity("memberStatisticsEntity");
+
+    public final com.project.singk.global.domain.QBaseTimeEntity _super = new com.project.singk.global.domain.QBaseTimeEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final NumberPath<Integer> totalActivityScore = createNumber("totalActivityScore", Integer.class);
+
+    public final NumberPath<Integer> totalReview = createNumber("totalReview", Integer.class);
+
+    public final NumberPath<Integer> totalReviewScore = createNumber("totalReviewScore", Integer.class);
+
+    public QMemberStatisticsEntity(String variable) {
+        super(MemberStatisticsEntity.class, forVariable(variable));
+    }
+
+    public QMemberStatisticsEntity(Path<? extends MemberStatisticsEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QMemberStatisticsEntity(PathMetadata metadata) {
+        super(MemberStatisticsEntity.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/project/singk/domain/review/infrastructure/QAlbumReviewEntity.java
+++ b/src/main/generated/com/project/singk/domain/review/infrastructure/QAlbumReviewEntity.java
@@ -62,8 +62,8 @@ public class QAlbumReviewEntity extends EntityPathBase<AlbumReviewEntity> {
 
     public QAlbumReviewEntity(Class<? extends AlbumReviewEntity> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
-        this.album = inits.isInitialized("album") ? new com.project.singk.domain.album.infrastructure.entity.QAlbumEntity(forProperty("album")) : null;
-        this.member = inits.isInitialized("member") ? new com.project.singk.domain.member.infrastructure.QMemberEntity(forProperty("member")) : null;
+        this.album = inits.isInitialized("album") ? new com.project.singk.domain.album.infrastructure.entity.QAlbumEntity(forProperty("album"), inits.get("album")) : null;
+        this.member = inits.isInitialized("member") ? new com.project.singk.domain.member.infrastructure.QMemberEntity(forProperty("member"), inits.get("member")) : null;
     }
 
 }

--- a/src/main/java/com/project/singk/domain/activity/domain/ActivityHistory.java
+++ b/src/main/java/com/project/singk/domain/activity/domain/ActivityHistory.java
@@ -1,0 +1,29 @@
+package com.project.singk.domain.activity.domain;
+
+import com.project.singk.domain.member.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ActivityHistory {
+    private final Long id;
+    private final ActivityType type;
+    private final int score;
+    private final Member member;
+
+    @Builder
+    public ActivityHistory(Long id, ActivityType type, int score, Member member) {
+        this.id = id;
+        this.type = type;
+        this.score = score;
+        this.member = member;
+    }
+
+    public static ActivityHistory from(ActivityType type, Member member) {
+        return ActivityHistory.builder()
+                .type(type)
+                .score(type.getScore())
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/com/project/singk/domain/activity/domain/ActivityType.java
+++ b/src/main/java/com/project/singk/domain/activity/domain/ActivityType.java
@@ -1,0 +1,33 @@
+package com.project.singk.domain.activity.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ActivityType {
+    ATTENDANCE(30),
+    /**
+        앨범 감상평 관련
+     */
+    WRITE_ALBUM_REVIEW(10),
+    RECOMMENDED_ALBUM_REVIEW(50),
+    REACT_ALBUM_REVIEW(5),
+    DELETE_ALBUM_REVIEW(-50),
+    /**
+         게시글 관련
+     */
+    WRITE_POST(10),
+    RECOMMENDED_POST(10),
+    REACT_POST(3),
+    DELETE_POST(-25),
+    /**
+        댓글 관련
+     */
+    WRITE_COMMENT(1),
+    RECOMMENDED_COMMENT(10),
+    REACT_COMMENT(1),
+    DELETE_COMMENT(-5);
+
+    private final int score;
+}

--- a/src/main/java/com/project/singk/domain/activity/infrastructure/ActivityHistoryEntity.java
+++ b/src/main/java/com/project/singk/domain/activity/infrastructure/ActivityHistoryEntity.java
@@ -1,0 +1,58 @@
+package com.project.singk.domain.activity.infrastructure;
+
+import com.project.singk.domain.activity.domain.ActivityHistory;
+import com.project.singk.domain.activity.domain.ActivityType;
+import com.project.singk.domain.member.infrastructure.MemberEntity;
+import com.project.singk.global.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "ACTIVITY_HISTORYS")
+@Getter
+@NoArgsConstructor
+public class ActivityHistoryEntity extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "activity_type", unique = true)
+    @Enumerated(EnumType.STRING)
+	private ActivityType type;
+
+	@Column(name = "activity_score")
+	private int score;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private MemberEntity member;
+
+    @Builder
+    public ActivityHistoryEntity(Long id, ActivityType type, int score, MemberEntity member) {
+        this.id = id;
+        this.type = type;
+        this.score = score;
+        this.member = member;
+    }
+
+    public static ActivityHistoryEntity from (ActivityHistory activity) {
+        return ActivityHistoryEntity.builder()
+                .id(activity.getId())
+                .type(activity.getType())
+                .score(activity.getScore())
+                .member(MemberEntity.from(activity.getMember()))
+                .build();
+    }
+
+    public ActivityHistory toModel() {
+        return ActivityHistory.builder()
+                .id(this.id)
+                .type(this.type)
+                .score(this.score)
+                .member(this.member.toModel())
+                .build();
+    }
+}

--- a/src/main/java/com/project/singk/domain/activity/infrastructure/ActivityHistoryEntity.java
+++ b/src/main/java/com/project/singk/domain/activity/infrastructure/ActivityHistoryEntity.java
@@ -19,7 +19,7 @@ public class ActivityHistoryEntity extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = "activity_type", unique = true)
+	@Column(name = "activity_type")
     @Enumerated(EnumType.STRING)
 	private ActivityType type;
 

--- a/src/main/java/com/project/singk/domain/activity/infrastructure/ActivityHistoryJpaRepository.java
+++ b/src/main/java/com/project/singk/domain/activity/infrastructure/ActivityHistoryJpaRepository.java
@@ -1,0 +1,6 @@
+package com.project.singk.domain.activity.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ActivityHistoryJpaRepository extends JpaRepository<ActivityHistoryEntity, Long> {
+}

--- a/src/main/java/com/project/singk/domain/activity/infrastructure/ActivityHistoryRepositoryImpl.java
+++ b/src/main/java/com/project/singk/domain/activity/infrastructure/ActivityHistoryRepositoryImpl.java
@@ -1,0 +1,18 @@
+package com.project.singk.domain.activity.infrastructure;
+
+import com.project.singk.domain.activity.domain.ActivityHistory;
+import com.project.singk.domain.activity.service.port.ActivityHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ActivityHistoryRepositoryImpl implements ActivityHistoryRepository {
+
+    private final ActivityHistoryJpaRepository activityHistoryJpaRepository;
+
+    @Override
+    public ActivityHistory save(ActivityHistory activityHistory) {
+        return activityHistoryJpaRepository.save(ActivityHistoryEntity.from(activityHistory)).toModel();
+    }
+}

--- a/src/main/java/com/project/singk/domain/activity/service/port/ActivityHistoryRepository.java
+++ b/src/main/java/com/project/singk/domain/activity/service/port/ActivityHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.project.singk.domain.activity.service.port;
+
+import com.project.singk.domain.activity.domain.ActivityHistory;
+
+public interface ActivityHistoryRepository {
+    ActivityHistory save(ActivityHistory activityHistory);
+}

--- a/src/main/java/com/project/singk/domain/album/controller/response/AlbumSimpleResponse.java
+++ b/src/main/java/com/project/singk/domain/album/controller/response/AlbumSimpleResponse.java
@@ -1,0 +1,32 @@
+package com.project.singk.domain.album.controller.response;
+
+import com.project.singk.domain.album.domain.Album;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@Builder
+@ToString
+public class AlbumSimpleResponse {
+
+    private String id;
+    private String name;
+    private List<ArtistResponse> artists;
+    private List<ImageResponse> images;
+
+    public static AlbumSimpleResponse from (Album album) {
+        return AlbumSimpleResponse.builder()
+                .id(album.getId())
+                .name(album.getName())
+                .artists(album.getArtists().stream()
+                        .map(ArtistResponse::from)
+                        .toList())
+                .images(album.getImages().stream()
+                        .map(ImageResponse::from)
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/com/project/singk/domain/album/domain/Album.java
+++ b/src/main/java/com/project/singk/domain/album/domain/Album.java
@@ -17,8 +17,9 @@ public class Album {
     private final List<Artist> artists;
     private final List<AlbumImage> images;
     private final AlbumReviewStatistics statistics;
+    private final LocalDateTime createdAt;
     @Builder
-    public Album(String id, String name, AlbumType type, LocalDateTime releasedAt, List<Track> tracks, List<Artist> artists, List<AlbumImage> images, AlbumReviewStatistics statistics) {
+    public Album(String id, String name, AlbumType type, LocalDateTime releasedAt, List<Track> tracks, List<Artist> artists, List<AlbumImage> images, AlbumReviewStatistics statistics, LocalDateTime createdAt) {
         this.id = id;
         this.name = name;
         this.type = type;
@@ -27,6 +28,7 @@ public class Album {
         this.artists = artists;
         this.images = images;
         this.statistics = statistics;
+        this.createdAt = createdAt;
     }
 
     public Album updateStatistic(AlbumReviewStatistics statistics) {
@@ -39,6 +41,7 @@ public class Album {
                 .artists(this.artists)
                 .images(this.images)
                 .statistics(statistics)
+                .createdAt(this.createdAt)
                 .build();
     }
 }

--- a/src/main/java/com/project/singk/domain/album/domain/Artist.java
+++ b/src/main/java/com/project/singk/domain/album/domain/Artist.java
@@ -3,14 +3,18 @@ package com.project.singk.domain.album.domain;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 public class Artist {
 	private final String id;
 	private final String name;
+    private final LocalDateTime createdAt;
 
 	@Builder
-    public Artist(String id, String name) {
+    public Artist(String id, String name, LocalDateTime createdAt) {
         this.id = id;
         this.name = name;
+        this.createdAt = createdAt;
     }
 }

--- a/src/main/java/com/project/singk/domain/album/domain/Track.java
+++ b/src/main/java/com/project/singk/domain/album/domain/Track.java
@@ -3,6 +3,8 @@ package com.project.singk.domain.album.domain;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 public class Track {
 	private final String id;
@@ -11,14 +13,16 @@ public class Track {
 	private final long duration;
 	private final boolean isPlayable;
 	private final String previewUrl;
+    private LocalDateTime createdAt;
 
 	@Builder
-    public Track(String id, String name, int trackNumber, long duration, boolean isPlayable, String previewUrl) {
+    public Track(String id, String name, int trackNumber, long duration, boolean isPlayable, String previewUrl, LocalDateTime createdAt) {
         this.id = id;
         this.name = name;
         this.trackNumber = trackNumber;
         this.duration = duration;
         this.isPlayable = isPlayable;
         this.previewUrl = previewUrl;
+        this.createdAt = createdAt;
     }
 }

--- a/src/main/java/com/project/singk/domain/album/infrastructure/entity/ArtistEntity.java
+++ b/src/main/java/com/project/singk/domain/album/infrastructure/entity/ArtistEntity.java
@@ -10,12 +10,13 @@ import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Persistable;
 
 @Entity
 @Table(name = "ARTISTS")
 @Getter
 @NoArgsConstructor
-public class ArtistEntity extends BaseTimeEntity {
+public class ArtistEntity extends BaseTimeEntity implements Persistable<String> {
 
 	@Id
 	@Column(updatable = false, length = 22)
@@ -41,6 +42,12 @@ public class ArtistEntity extends BaseTimeEntity {
 		return Artist.builder()
 			.id(this.id)
 			.name(this.name)
+            .createdAt(this.getCreatedAt())
 			.build();
 	}
+
+    @Override
+    public boolean isNew() {
+        return this.getCreatedAt() == null;
+    }
 }

--- a/src/main/java/com/project/singk/domain/album/infrastructure/entity/TrackEntity.java
+++ b/src/main/java/com/project/singk/domain/album/infrastructure/entity/TrackEntity.java
@@ -10,12 +10,13 @@ import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Persistable;
 
 @Entity
 @Table(name = "TRACKS")
 @Getter
 @NoArgsConstructor
-public class TrackEntity extends BaseTimeEntity {
+public class TrackEntity extends BaseTimeEntity implements Persistable<String> {
 
 	@Id
 	@Column(updatable = false, length = 22)
@@ -65,6 +66,12 @@ public class TrackEntity extends BaseTimeEntity {
 			.duration(this.duration)
 			.isPlayable(this.isPlayable)
 			.previewUrl(this.previewUrl)
+                .createdAt(this.getCreatedAt())
 			.build();
 	}
+
+    @Override
+    public boolean isNew() {
+        return this.getCreatedAt() == null;
+    }
 }

--- a/src/main/java/com/project/singk/domain/member/controller/response/MemberResponse.java
+++ b/src/main/java/com/project/singk/domain/member/controller/response/MemberResponse.java
@@ -16,12 +16,14 @@ public class MemberResponse {
 	private String imageUrl;
 	private String nickname;
 	private String gender;
+    private MemberStatisticsResponse statistics;
 	public static MemberResponse from(Member member, String imageUrl) {
 		return MemberResponse.builder()
 			.id(member.getId())
 			.imageUrl(imageUrl)
 			.nickname(member.getNickname())
 			.gender(member.getGender().getName())
+            .statistics(MemberStatisticsResponse.from(member.getStatistics()))
 			.build();
 	}
 }

--- a/src/main/java/com/project/singk/domain/member/controller/response/MemberStatisticsResponse.java
+++ b/src/main/java/com/project/singk/domain/member/controller/response/MemberStatisticsResponse.java
@@ -1,0 +1,25 @@
+package com.project.singk.domain.member.controller.response;
+
+import com.project.singk.domain.member.domain.MemberStatistics;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+public class MemberStatisticsResponse {
+    private int totalActivityScore;
+    private int totalReview;
+    private int totalReviewScore;
+    private double averageReviewScore;
+
+    public static MemberStatisticsResponse from (MemberStatistics statistics) {
+        return MemberStatisticsResponse.builder()
+                .totalActivityScore(statistics.getTotalActivityScore())
+                .totalReview(statistics.getTotalReview())
+                .totalReviewScore(statistics.getTotalReviewScore())
+                .averageReviewScore(statistics.calculateAverage(statistics.getTotalReviewScore(), statistics.getTotalReview()))
+                .build();
+    }
+}

--- a/src/main/java/com/project/singk/domain/member/controller/response/MyProfileResponse.java
+++ b/src/main/java/com/project/singk/domain/member/controller/response/MyProfileResponse.java
@@ -21,6 +21,7 @@ public class MyProfileResponse {
 	private String gender;
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
 	private LocalDateTime birthday;
+    private MemberStatisticsResponse statistics;
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
 	private LocalDateTime createdAt;
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
@@ -34,6 +35,7 @@ public class MyProfileResponse {
 			.name(member.getName())
 			.gender(member.getGender().getName())
 			.birthday(member.getBirthday())
+            .statistics(MemberStatisticsResponse.from(member.getStatistics()))
 			.createdAt(member.getCreatedAt())
 			.modifiedAt(member.getModifiedAt())
 			.build();

--- a/src/main/java/com/project/singk/domain/member/domain/Member.java
+++ b/src/main/java/com/project/singk/domain/member/domain/Member.java
@@ -22,10 +22,11 @@ public class Member {
 	private final Role role;
 	private final LocalDateTime createdAt;
 	private final LocalDateTime modifiedAt;
+    private final MemberStatistics statistics;
 
 	@Builder
 	public Member(Long id, String email, String password, String imageUrl, String nickname, Gender gender, String name,
-		LocalDateTime birthday, Role role, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+		LocalDateTime birthday, Role role, LocalDateTime createdAt, LocalDateTime modifiedAt, MemberStatistics statistics) {
 		this.id = id;
 		this.email = email;
 		this.password = password;
@@ -37,10 +38,12 @@ public class Member {
 		this.role = role;
 		this.createdAt = createdAt;
 		this.modifiedAt = modifiedAt;
+        this.statistics = statistics;
 	}
 
 	public static Member from(
 		MemberCreate memberCreate,
+        MemberStatistics statistics,
 		PasswordEncoderHolder passwordEncoderHolder
 	) {
 		return Member.builder()
@@ -51,6 +54,7 @@ public class Member {
 			.name(memberCreate.getName())
 			.birthday(LocalDate.parse(memberCreate.getBirthday(), DateTimeFormatter.ofPattern("yyyy-MM-dd")).atStartOfDay())
 			.role(Role.ROLE_USER)
+            .statistics(statistics)
 			.build();
 
 	}
@@ -67,6 +71,7 @@ public class Member {
 			.role(this.role)
 			.createdAt(this.createdAt)
 			.modifiedAt(this.modifiedAt)
+            .statistics(this.statistics)
 			.build();
 	}
 
@@ -83,7 +88,25 @@ public class Member {
 			.role(this.role)
 			.createdAt(this.createdAt)
 			.modifiedAt(this.modifiedAt)
+            .statistics(this.statistics)
 			.build();
 	}
+
+    public Member updateStatistic(MemberStatistics statistics) {
+        return Member.builder()
+                .id(this.id)
+                .email(this.email)
+                .password(this.password)
+                .imageUrl(imageUrl)
+                .nickname(this.nickname)
+                .gender(this.gender)
+                .name(this.name)
+                .birthday(this.birthday)
+                .role(this.role)
+                .createdAt(this.createdAt)
+                .modifiedAt(this.modifiedAt)
+                .statistics(statistics)
+                .build();
+    }
 
 }

--- a/src/main/java/com/project/singk/domain/member/domain/MemberStatistics.java
+++ b/src/main/java/com/project/singk/domain/member/domain/MemberStatistics.java
@@ -20,11 +20,26 @@ public class MemberStatistics {
         this.totalReviewScore = totalReviewScore;
     }
 
+    public double calculateAverage(long a, long b) {
+        if (b == 0) return 0.0;
+
+        return Math.round((double) a / b * 100) / 100.0;
+    }
+
     public static MemberStatistics empty() {
         return MemberStatistics.builder()
                 .totalActivityScore(0)
                 .totalReview(0)
                 .totalReviewScore(0)
+                .build();
+    }
+
+    public MemberStatistics updateActivity(ActivityHistory activityHistory) {
+        return MemberStatistics.builder()
+                .id(this.id)
+                .totalActivityScore(this.totalActivityScore + activityHistory.getScore())
+                .totalReview(this.totalReview)
+                .totalReviewScore(this.totalReviewScore)
                 .build();
     }
 

--- a/src/main/java/com/project/singk/domain/member/domain/MemberStatistics.java
+++ b/src/main/java/com/project/singk/domain/member/domain/MemberStatistics.java
@@ -63,7 +63,7 @@ public class MemberStatistics {
     private MemberStatistics deleteReview(AlbumReview review, ActivityHistory activityHistory) {
         return MemberStatistics.builder()
                 .id(this.id)
-                .totalActivityScore(this.totalActivityScore - activityHistory.getScore())
+                .totalActivityScore(this.totalActivityScore + activityHistory.getScore())
                 .totalReview(this.totalReview - 1)
                 .totalReviewScore(this.totalReviewScore - review.getScore())
                 .build();

--- a/src/main/java/com/project/singk/domain/member/domain/MemberStatistics.java
+++ b/src/main/java/com/project/singk/domain/member/domain/MemberStatistics.java
@@ -1,0 +1,56 @@
+package com.project.singk.domain.member.domain;
+
+import com.project.singk.domain.activity.domain.ActivityHistory;
+import com.project.singk.domain.review.domain.AlbumReview;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberStatistics {
+    private Long id;
+    private final int totalActivityScore;
+    private final int totalReview;
+    private final int totalReviewScore;
+
+    @Builder
+    public MemberStatistics(Long id, int totalActivityScore, int totalReview, int totalReviewScore) {
+        this.id = id;
+        this.totalActivityScore = totalActivityScore;
+        this.totalReview = totalReview;
+        this.totalReviewScore = totalReviewScore;
+    }
+
+    public static MemberStatistics empty() {
+        return MemberStatistics.builder()
+                .totalActivityScore(0)
+                .totalReview(0)
+                .totalReviewScore(0)
+                .build();
+    }
+
+    public MemberStatistics updateReview(AlbumReview albumReview, ActivityHistory activityHistory, boolean isDelete) {
+        if (isDelete) {
+            return deleteReview(albumReview, activityHistory);
+        }
+
+        return createReview(albumReview, activityHistory);
+    }
+
+    private MemberStatistics createReview(AlbumReview review, ActivityHistory activityHistory) {
+        return MemberStatistics.builder()
+                .id(this.id)
+                .totalActivityScore(this.totalActivityScore + activityHistory.getScore())
+                .totalReview(this.totalReview + 1)
+                .totalReviewScore(this.totalReviewScore + review.getScore())
+                .build();
+    }
+
+    private MemberStatistics deleteReview(AlbumReview review, ActivityHistory activityHistory) {
+        return MemberStatistics.builder()
+                .id(this.id)
+                .totalActivityScore(this.totalActivityScore - activityHistory.getScore())
+                .totalReview(this.totalReview - 1)
+                .totalReviewScore(this.totalReviewScore - review.getScore())
+                .build();
+    }
+}

--- a/src/main/java/com/project/singk/domain/member/infrastructure/MemberEntity.java
+++ b/src/main/java/com/project/singk/domain/member/infrastructure/MemberEntity.java
@@ -7,19 +7,10 @@ import com.project.singk.domain.member.domain.Member;
 import com.project.singk.domain.member.domain.Role;
 import com.project.singk.global.domain.BaseTimeEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
+import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Entity
 @Table(name = "MEMBERS")
@@ -57,9 +48,13 @@ public class MemberEntity extends BaseTimeEntity {
 	@Column(name = "role")
 	private Role role;
 
+    @JoinColumn(name = "statistic_id")
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    private MemberStatisticsEntity statistics;
+
 	@Builder
 	public MemberEntity(Long id, String email, String password, String imageUrl, String nickname, Gender gender,
-		String name, LocalDateTime birthday, Role role) {
+		String name, LocalDateTime birthday, Role role, MemberStatisticsEntity statistics) {
 		this.id = id;
 		this.email = email;
 		this.password = password;
@@ -69,6 +64,7 @@ public class MemberEntity extends BaseTimeEntity {
 		this.name = name;
 		this.birthday = birthday;
 		this.role = role;
+        this.statistics = statistics;
 	}
 
 	public static MemberEntity from (Member member) {
@@ -82,6 +78,7 @@ public class MemberEntity extends BaseTimeEntity {
 			.name(member.getName())
 			.birthday(member.getBirthday())
 			.role(member.getRole())
+            .statistics(MemberStatisticsEntity.from(member.getStatistics()))
 			.build();
 	}
 
@@ -96,6 +93,7 @@ public class MemberEntity extends BaseTimeEntity {
 			.name(this.name)
 			.birthday(this.birthday)
 			.role(this.role)
+            .statistics(this.statistics.toModel())
 			.createdAt(this.getCreatedAt())
 			.modifiedAt(this.getModifiedAt())
 			.build();

--- a/src/main/java/com/project/singk/domain/member/infrastructure/MemberStatisticsEntity.java
+++ b/src/main/java/com/project/singk/domain/member/infrastructure/MemberStatisticsEntity.java
@@ -1,0 +1,58 @@
+package com.project.singk.domain.member.infrastructure;
+
+import com.project.singk.domain.member.domain.MemberStatistics;
+import com.project.singk.global.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Table(name = "MEMBER_STATISTICS")
+@Getter
+@NoArgsConstructor
+public class MemberStatisticsEntity extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+    @ColumnDefault("0")
+    @Column(name = "total_activity_score")
+    private int totalActivityScore;
+
+    @ColumnDefault("0")
+    @Column(name = "total_review")
+    private int totalReview;
+
+    @ColumnDefault("0")
+    @Column(name = "total_review_score")
+    private int totalReviewScore;
+
+    @Builder
+    public MemberStatisticsEntity(Long id, int totalActivityScore, int totalReview, int totalReviewScore) {
+        this.id = id;
+        this.totalActivityScore = totalActivityScore;
+        this.totalReview = totalReview;
+        this.totalReviewScore = totalReviewScore;
+    }
+
+    public static MemberStatisticsEntity from(MemberStatistics statistics) {
+        return MemberStatisticsEntity.builder()
+                .id(statistics.getId())
+                .totalActivityScore(statistics.getTotalActivityScore())
+                .totalReview(statistics.getTotalReview())
+                .totalReviewScore(statistics.getTotalReviewScore())
+                .build();
+    }
+
+    public MemberStatistics toModel() {
+        return MemberStatistics.builder()
+                .id(this.id)
+                .totalActivityScore(this.totalActivityScore)
+                .totalReview(this.totalReview)
+                .totalReviewScore(this.totalReviewScore)
+                .build();
+    }
+}

--- a/src/main/java/com/project/singk/domain/member/service/AuthServiceImpl.java
+++ b/src/main/java/com/project/singk/domain/member/service/AuthServiceImpl.java
@@ -1,5 +1,6 @@
 package com.project.singk.domain.member.service;
 
+import com.project.singk.domain.member.domain.MemberStatistics;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
@@ -106,7 +107,8 @@ public class AuthServiceImpl implements AuthService {
 
 	@Override
 	public PkResponseDto signup(MemberCreate memberCreate) {
-		Member member = Member.from(memberCreate, passwordEncoderHolder);
+        MemberStatistics statistics = MemberStatistics.empty();
+		Member member = Member.from(memberCreate, statistics, passwordEncoderHolder);
 
 		if (memberRepository.existsByEmail(member.getEmail())) {
 			throw new ApiException(AppHttpStatus.DUPLICATE_MEMBER);

--- a/src/main/java/com/project/singk/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/project/singk/domain/review/controller/ReviewController.java
@@ -5,8 +5,11 @@ import com.project.singk.domain.review.controller.port.ReviewService;
 import com.project.singk.domain.review.controller.request.ReviewSort;
 import com.project.singk.domain.review.controller.response.AlbumReviewResponse;
 import com.project.singk.domain.review.controller.response.AlbumReviewStatisticsResponse;
+import com.project.singk.domain.review.controller.response.MyAlbumReviewResponse;
+import com.project.singk.global.api.PageResponse;
 import com.project.singk.global.validate.ValidEnum;
 import jakarta.validation.Valid;
+import org.hibernate.validator.constraints.Range;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -39,12 +42,28 @@ public class ReviewController {
         ));
 	}
     @GetMapping("/albums/{albumId}")
-	public BaseResponse<List<AlbumReviewResponse>> getAlbumReviews(
+	public BaseResponse<PageResponse<AlbumReviewResponse>> getAlbumReviews(
 		@PathVariable(name = "albumId") String albumId,
+        @Range(min = 0, max = 1000, message = "offset은 0에서 1000사이의 값 이어야 합니다.") @RequestParam("offset") int offset,
+        @Range(min = 0, max = 50, message = "limit은 0에서 50사이의 값 이어야 합니다.") @RequestParam("limit") int limit,
         @RequestParam(name = "sort") @ValidEnum(enumClass = ReviewSort.class) String sort
 	) {
-		return BaseResponse.ok(reviewService.getAlbumReviews(albumId, sort));
+		return BaseResponse.ok(reviewService.getAlbumReviews(albumId, offset, limit, sort));
 	}
+
+    @GetMapping("/albums/me")
+    public BaseResponse<PageResponse<MyAlbumReviewResponse>> getMyAlbumReview(
+        @Range(min = 0, max = 1000, message = "offset은 0에서 1000사이의 값 이어야 합니다.") @RequestParam("offset") int offset,
+        @Range(min = 0, max = 50, message = "limit은 0에서 50사이의 값 이어야 합니다.") @RequestParam("limit") int limit,
+        @RequestParam(name = "sort") @ValidEnum(enumClass = ReviewSort.class) String sort
+    ) {
+        return BaseResponse.ok(reviewService.getMyAlbumReview(
+                authService.getLoginMemberId(),
+                offset,
+                limit,
+                sort)
+        );
+    }
 
     @DeleteMapping("{albumReviewId}/albums/{albumId}")
 	public BaseResponse<Void> deleteAlbumReview(

--- a/src/main/java/com/project/singk/domain/review/controller/port/ReviewService.java
+++ b/src/main/java/com/project/singk/domain/review/controller/port/ReviewService.java
@@ -2,7 +2,9 @@ package com.project.singk.domain.review.controller.port;
 
 import com.project.singk.domain.review.controller.response.AlbumReviewResponse;
 import com.project.singk.domain.review.controller.response.AlbumReviewStatisticsResponse;
+import com.project.singk.domain.review.controller.response.MyAlbumReviewResponse;
 import com.project.singk.domain.review.domain.AlbumReviewCreate;
+import com.project.singk.global.api.PageResponse;
 import com.project.singk.global.domain.PkResponseDto;
 
 import java.util.List;
@@ -10,6 +12,7 @@ import java.util.List;
 public interface ReviewService {
     PkResponseDto createAlbumReview(Long memberId, String albumId, AlbumReviewCreate albumReviewCreate);
     void deleteAlbumReview(Long memberId, String albumId, Long albumReviewId);
-    List<AlbumReviewResponse> getAlbumReviews(String albumId, String sort);
+    PageResponse<AlbumReviewResponse> getAlbumReviews(String albumId, int offset, int limit, String sort);
     AlbumReviewStatisticsResponse getAlbumReviewStatistics(String albumId);
+    PageResponse<MyAlbumReviewResponse> getMyAlbumReview(Long memberId, int offset, int limit, String sort);
 }

--- a/src/main/java/com/project/singk/domain/review/controller/response/MyAlbumReviewResponse.java
+++ b/src/main/java/com/project/singk/domain/review/controller/response/MyAlbumReviewResponse.java
@@ -1,0 +1,36 @@
+package com.project.singk.domain.review.controller.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.project.singk.domain.album.controller.response.AlbumSimpleResponse;
+import com.project.singk.domain.review.domain.AlbumReview;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@ToString
+public class MyAlbumReviewResponse {
+    private Long id;
+    private String content;
+    private int score;
+    private int pros;
+    private int cons;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime createdAt;
+    private AlbumSimpleResponse album;
+
+    public static MyAlbumReviewResponse from (AlbumReview albumReview) {
+        return MyAlbumReviewResponse.builder()
+                .id(albumReview.getId())
+                .content(albumReview.getContent())
+                .score(albumReview.getScore())
+                .pros(albumReview.getProsCount())
+                .cons(albumReview.getConsCount())
+                .createdAt(albumReview.getCreatedAt())
+                .album(AlbumSimpleResponse.from(albumReview.getAlbum()))
+                .build();
+    }
+}

--- a/src/main/java/com/project/singk/domain/review/infrastructure/AlbumReviewEntity.java
+++ b/src/main/java/com/project/singk/domain/review/infrastructure/AlbumReviewEntity.java
@@ -1,20 +1,13 @@
 package com.project.singk.domain.review.infrastructure;
 
 import com.project.singk.domain.review.domain.AlbumReview;
+import jakarta.persistence.*;
 import org.hibernate.annotations.ColumnDefault;
 
 import com.project.singk.domain.album.infrastructure.entity.AlbumEntity;
 import com.project.singk.domain.member.infrastructure.MemberEntity;
 import com.project.singk.global.domain.BaseTimeEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -42,11 +35,11 @@ public class AlbumReviewEntity extends BaseTimeEntity {
 	@Column(name = "cons_count")
 	private int consCount;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
 	private MemberEntity member;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "album_id")
 	private AlbumEntity album;
 

--- a/src/main/java/com/project/singk/domain/review/infrastructure/AlbumReviewRepositoryImpl.java
+++ b/src/main/java/com/project/singk/domain/review/infrastructure/AlbumReviewRepositoryImpl.java
@@ -2,30 +2,30 @@ package com.project.singk.domain.review.infrastructure;
 
 import com.project.singk.domain.album.domain.Album;
 import com.project.singk.domain.album.infrastructure.entity.AlbumEntity;
-import com.project.singk.domain.album.infrastructure.entity.QAlbumEntity;
-import com.project.singk.domain.member.domain.Gender;
 import com.project.singk.domain.member.domain.Member;
 import com.project.singk.domain.member.infrastructure.MemberEntity;
-import com.project.singk.domain.member.infrastructure.QMemberEntity;
 import com.project.singk.domain.review.controller.request.ReviewSort;
 import com.project.singk.domain.review.domain.AlbumReview;
-import com.project.singk.domain.review.domain.AlbumReviewStatistics;
-import com.project.singk.domain.review.domain.QAlbumReviewStatistics;
 import com.project.singk.domain.review.service.port.AlbumReviewRepository;
 import com.project.singk.global.api.ApiException;
 import com.project.singk.global.api.AppHttpStatus;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
 import static com.project.singk.domain.album.infrastructure.entity.QAlbumEntity.albumEntity;
-import static com.project.singk.domain.review.infrastructure.QAlbumReviewStatisticsEntity.albumReviewStatisticsEntity;
+import static com.project.singk.domain.member.infrastructure.QMemberEntity.memberEntity;
+import static com.project.singk.domain.review.infrastructure.QAlbumReviewEntity.albumReviewEntity;
 
 @Repository
 @RequiredArgsConstructor
@@ -62,36 +62,59 @@ public class AlbumReviewRepositoryImpl implements AlbumReviewRepository {
     }
 
     @Override
-    public List<AlbumReview> getAllByAlbumId(String albumId, ReviewSort sort) {
-        QAlbumReviewEntity albumReview = QAlbumReviewEntity.albumReviewEntity;
-        QMemberEntity member = QMemberEntity.memberEntity;
-        QAlbumEntity album = albumEntity;
+    public Page<AlbumReview> getAllByAlbumId(String albumId, int offset, int limit, String sort) {
 
-        return jpaQueryFactory.select(Projections.fields(AlbumReviewEntity.class,
-                    albumReview.id,
-                    albumReview.content,
-                    albumReview.score,
-                    albumReview.prosCount,
-                    albumReview.consCount,
-                    albumReview.createdAt,
-                    albumReview.member,
-                    albumReview.album
-                ))
-                .from(albumReview)
-                .innerJoin(albumReview.member, member)
-                .innerJoin(albumReview.album, album)
-                .where(album.id.eq(albumId))
-                .orderBy(createOrderSpecifier(sort, albumReview))
+        List<AlbumReview> reviews = jpaQueryFactory.select(albumReviewEntity)
+                .from(albumReviewEntity)
+                .innerJoin(albumReviewEntity.member, memberEntity).fetchJoin()
+                .innerJoin(albumReviewEntity.album, albumEntity).fetchJoin()
+                .where(albumEntity.id.eq(albumId))
+                .orderBy(createOrderSpecifier(ReviewSort.valueOf(sort)))
                 .fetch()
                 .stream()
                 .map(AlbumReviewEntity::toModel)
                 .toList();
+
+        JPAQuery<Long> count = jpaQueryFactory.select(albumReviewEntity.count())
+                .from(albumReviewEntity)
+                .join(albumReviewEntity.member, memberEntity)
+                .join(albumReviewEntity.album, albumEntity)
+                .where(albumEntity.id.eq(albumId));
+
+        Pageable pageable = PageRequest.ofSize(limit);
+
+        return PageableExecutionUtils.getPage(reviews, pageable, count::fetchOne);
     }
 
-    private OrderSpecifier createOrderSpecifier(ReviewSort sort, QAlbumReviewEntity albumReview) {
+    @Override
+    public Page<AlbumReview> getAllByMemberId(Long memberId, int offset, int limit, String sort) {
+        List<AlbumReview> reviews = jpaQueryFactory.select(albumReviewEntity)
+                .from(albumReviewEntity)
+                .innerJoin(albumReviewEntity.member, memberEntity).fetchJoin()
+                .innerJoin(albumReviewEntity.album, albumEntity).fetchJoin()
+                .where(memberEntity.id.eq(memberId))
+                .orderBy(createOrderSpecifier(ReviewSort.valueOf(sort)))
+                .offset(offset)
+                .limit(limit)
+                .fetch().stream()
+                .map(AlbumReviewEntity::toModel)
+                .toList();
+
+        JPAQuery<Long> count = jpaQueryFactory.select(albumReviewEntity.count())
+                .from(albumReviewEntity)
+                .join(albumReviewEntity.member, memberEntity)
+                .join(albumReviewEntity.album, albumEntity)
+                .where(memberEntity.id.eq(memberId));
+
+        Pageable pageable = PageRequest.ofSize(limit);
+
+        return PageableExecutionUtils.getPage(reviews, pageable, count::fetchOne);
+    }
+
+    private OrderSpecifier createOrderSpecifier(ReviewSort sort) {
         return switch (sort) {
-            case NEW -> new OrderSpecifier(Order.DESC, albumReview.createdAt);
-            case LIKES -> new OrderSpecifier(Order.DESC, albumReview.prosCount);
+            case NEW -> new OrderSpecifier(Order.DESC, albumReviewEntity.createdAt);
+            case LIKES -> new OrderSpecifier(Order.DESC, albumReviewEntity.prosCount);
         };
     }
 

--- a/src/main/java/com/project/singk/domain/review/service/port/AlbumReviewRepository.java
+++ b/src/main/java/com/project/singk/domain/review/service/port/AlbumReviewRepository.java
@@ -4,6 +4,7 @@ import com.project.singk.domain.album.domain.Album;
 import com.project.singk.domain.member.domain.Member;
 import com.project.singk.domain.review.controller.request.ReviewSort;
 import com.project.singk.domain.review.domain.AlbumReview;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,6 +15,7 @@ public interface AlbumReviewRepository {
     AlbumReview getById(Long id);
     Optional<AlbumReview> findById(Long id);
     boolean existsByMemberAndAlbum(Member member, Album album);
-    List<AlbumReview> getAllByAlbumId(String albumId, ReviewSort sort);
+    Page<AlbumReview> getAllByAlbumId(String albumId, int offset, int limit, String sort);
+    Page<AlbumReview> getAllByMemberId(Long memberId, int offset, int limit, String sort);
     void delete(AlbumReview albumReview);
 }

--- a/src/test/java/com/project/singk/domain/activity/domain/ActivityHistoryTest.java
+++ b/src/test/java/com/project/singk/domain/activity/domain/ActivityHistoryTest.java
@@ -1,0 +1,31 @@
+package com.project.singk.domain.activity.domain;
+
+import com.project.singk.domain.member.domain.Member;
+import com.project.singk.domain.member.domain.MemberStatistics;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class ActivityHistoryTest {
+
+    @Test
+    public void ActivityType과_Member로_ActivityHistory를_만들_수_있다() {
+        // given
+        ActivityType type = ActivityType.ATTENDANCE;
+        Member member = Member.builder()
+                .id(1L)
+                .email("singk@gmail.com")
+                .statistics(MemberStatistics.empty())
+                .build();
+        // when
+        ActivityHistory activityHistory = ActivityHistory.from(type, member);
+
+        // then
+        assertAll(
+                () -> assertThat(activityHistory.getScore()).isEqualTo(30),
+                () -> assertThat(activityHistory.getType()).isEqualTo(ActivityType.ATTENDANCE),
+                () -> assertThat(activityHistory.getMember().getEmail()).isEqualTo("singk@gmail.com")
+        );
+    }
+}

--- a/src/test/java/com/project/singk/domain/album/controller/response/AlbumSimpleResponseTest.java
+++ b/src/test/java/com/project/singk/domain/album/controller/response/AlbumSimpleResponseTest.java
@@ -1,0 +1,54 @@
+package com.project.singk.domain.album.controller.response;
+
+import com.project.singk.domain.album.domain.Album;
+import com.project.singk.domain.album.domain.AlbumImage;
+import com.project.singk.domain.album.domain.AlbumType;
+import com.project.singk.domain.album.domain.Artist;
+import com.project.singk.domain.review.domain.AlbumReviewStatistics;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AlbumSimpleResponseTest {
+    @Test
+    public void Album으로_AlbumSimpleResponseTest를_만들_수_있다() {
+        // given
+        List<Artist> artists = List.of(
+                Artist.builder()
+                        .name("NewJeans")
+                        .build()
+        );
+        List<AlbumImage> images = List.of(
+                AlbumImage.builder()
+                        .imageUrl("https://i.scdn.co/image/ab67616d0000b273b657fbb27b17e7bd4691c2b2")
+                        .build()
+        );
+
+        AlbumReviewStatistics statistics = AlbumReviewStatistics.empty();
+
+        Album album = Album.builder()
+                .id("0EhZEM4RRz0yioTgucDhJq")
+                .name("How Sweet")
+                .type(AlbumType.EP)
+                .releasedAt(LocalDateTime.of(2024, 5, 24, 0, 0, 0))
+                .artists(artists)
+                .images(images)
+                .statistics(statistics)
+                .build();
+
+        // when
+        AlbumSimpleResponse response = AlbumSimpleResponse.from(album);
+
+        // then
+        assertAll(
+                () -> assertThat(response.getId()).isEqualTo("0EhZEM4RRz0yioTgucDhJq"),
+                () -> assertThat(response.getName()).isEqualTo("How Sweet"),
+                () -> assertThat(response.getArtists().get(0).getName()).isEqualTo("NewJeans"),
+                () -> assertThat(response.getImages().get(0).getImageUrl()).isEqualTo("https://i.scdn.co/image/ab67616d0000b273b657fbb27b17e7bd4691c2b2")
+        );
+    }
+}

--- a/src/test/java/com/project/singk/domain/member/controller/response/MemberResponseTest.java
+++ b/src/test/java/com/project/singk/domain/member/controller/response/MemberResponseTest.java
@@ -2,6 +2,7 @@ package com.project.singk.domain.member.controller.response;
 
 import com.project.singk.domain.member.domain.Gender;
 import com.project.singk.domain.member.domain.Member;
+import com.project.singk.domain.member.domain.MemberStatistics;
 import com.project.singk.domain.member.domain.Role;
 import org.junit.jupiter.api.Test;
 
@@ -24,6 +25,7 @@ class MemberResponseTest {
                 .birthday(LocalDate.of(1999, 12, 30).atStartOfDay())
                 .gender(Gender.MALE)
                 .role(Role.ROLE_USER)
+                .statistics(MemberStatistics.empty())
                 .build();
 
         String imageUrl = "imageUrl";
@@ -36,7 +38,8 @@ class MemberResponseTest {
                 () -> assertThat(memberResponse.getId()).isEqualTo(1L),
                 () -> assertThat(memberResponse.getImageUrl()).isEqualTo(imageUrl),
                 () -> assertThat(memberResponse.getNickname()).isEqualTo("SingK"),
-                () -> assertThat(memberResponse.getGender()).isEqualTo("남성")
+                () -> assertThat(memberResponse.getGender()).isEqualTo("남성"),
+                () -> assertThat(memberResponse.getStatistics().getTotalActivityScore()).isEqualTo(0)
         );
     }
 

--- a/src/test/java/com/project/singk/domain/member/controller/response/MemberStatisticsResponseTest.java
+++ b/src/test/java/com/project/singk/domain/member/controller/response/MemberStatisticsResponseTest.java
@@ -1,0 +1,27 @@
+package com.project.singk.domain.member.controller.response;
+
+import com.project.singk.domain.member.domain.MemberStatistics;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class MemberStatisticsResponseTest {
+
+    @Test
+    public void MemberStatistics로_응답을_생성할_수_있다() {
+        // given
+        MemberStatistics statistics = MemberStatistics.empty();
+
+        // when
+        MemberStatisticsResponse response = MemberStatisticsResponse.from(statistics);
+
+        // then
+        assertAll(
+                () -> assertThat(response.getAverageReviewScore()).isEqualTo(0.0),
+                () -> assertThat(response.getTotalReview()).isEqualTo(0),
+                () -> assertThat(response.getTotalActivityScore()).isEqualTo(0),
+                () -> assertThat(response.getTotalReviewScore()).isEqualTo(0)
+        );
+    }
+}

--- a/src/test/java/com/project/singk/domain/member/controller/response/MyProfileResponseTest.java
+++ b/src/test/java/com/project/singk/domain/member/controller/response/MyProfileResponseTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
 
+import com.project.singk.domain.member.domain.MemberStatistics;
 import org.junit.jupiter.api.Test;
 
 import com.project.singk.domain.member.domain.Gender;
@@ -25,6 +26,7 @@ class MyProfileResponseTest {
 			.birthday(LocalDate.of(1999, 12, 30).atStartOfDay())
 			.gender(Gender.MALE)
 			.role(Role.ROLE_USER)
+            .statistics(MemberStatistics.empty())
 			.build();
 		String imageUrl = "imageUrl";
 
@@ -38,7 +40,8 @@ class MyProfileResponseTest {
 			() -> assertThat(myProfileResponse.getNickname()).isEqualTo("SingK"),
 			() -> assertThat(myProfileResponse.getName()).isEqualTo("김철수"),
 			() -> assertThat(myProfileResponse.getBirthday()).isEqualTo("1999-12-30T00:00"),
-			() -> assertThat(myProfileResponse.getGender()).isEqualTo("남성")
+			() -> assertThat(myProfileResponse.getGender()).isEqualTo("남성"),
+			() -> assertThat(myProfileResponse.getStatistics().getTotalActivityScore()).isEqualTo(0)
 		);
 	}
 }

--- a/src/test/java/com/project/singk/domain/member/domain/MemberStatisticsTest.java
+++ b/src/test/java/com/project/singk/domain/member/domain/MemberStatisticsTest.java
@@ -1,0 +1,108 @@
+package com.project.singk.domain.member.domain;
+
+import com.project.singk.domain.activity.domain.ActivityHistory;
+import com.project.singk.domain.activity.domain.ActivityType;
+import com.project.singk.domain.review.domain.AlbumReview;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class MemberStatisticsTest {
+
+    @Test
+    public void 비어있는_MemberStatistic를_생성할_수_있다() {
+        // given
+
+        // when
+        MemberStatistics statistics = MemberStatistics.empty();
+
+        // then
+        assertAll(
+                () -> assertThat(statistics.getTotalActivityScore()).isEqualTo(0),
+                () -> assertThat(statistics.getTotalReview()).isEqualTo(0),
+                () -> assertThat(statistics.getTotalReviewScore()).isEqualTo(0)
+        );
+    }
+
+    @Test
+    public void ActivityHistory를_받아서_MemberStatistics에_반영할_수_있다() {
+        // given
+        MemberStatistics statistics = MemberStatistics.empty();
+
+        ActivityHistory activityHistory = ActivityHistory.builder()
+                .type(ActivityType.ATTENDANCE)
+                .score(ActivityType.ATTENDANCE.getScore())
+                .build();
+        // when
+        statistics = statistics.updateActivity(activityHistory);
+
+        // then
+        assertThat(statistics.getTotalActivityScore()).isEqualTo(30);
+        assertThat(statistics.getTotalReview()).isEqualTo(0);
+        assertThat(statistics.getTotalReviewScore()).isEqualTo(0);
+    }
+
+    @Test
+    public void AlbumReview와_ActivityHistory를_받아서_MemberStatistics에_추가할_수_있다() {
+        // given
+        MemberStatistics statistics = MemberStatistics.empty();
+
+        ActivityHistory activityHistory = ActivityHistory.builder()
+                .type(ActivityType.WRITE_ALBUM_REVIEW)
+                .score(ActivityType.WRITE_ALBUM_REVIEW.getScore())
+                .build();
+
+        AlbumReview review = AlbumReview.builder()
+                .score(5)
+                .build();
+
+        // when
+        statistics = statistics.updateReview(review, activityHistory, false);
+
+        // then
+        assertThat(statistics.getTotalActivityScore()).isEqualTo(10);
+        assertThat(statistics.getTotalReview()).isEqualTo(1);
+        assertThat(statistics.getTotalReviewScore()).isEqualTo(5);
+    }
+    @Test
+
+    public void AlbumReview와_ActivityHistory를_받아서_MemberStatistics에_삭제할_수_있다() {
+        // given
+        MemberStatistics statistics = MemberStatistics.builder()
+                .totalActivityScore(10)
+                .totalReview(1)
+                .totalReviewScore(5)
+                .build();
+
+        ActivityHistory activityHistory = ActivityHistory.builder()
+                .type(ActivityType.DELETE_ALBUM_REVIEW)
+                .score(ActivityType.DELETE_ALBUM_REVIEW.getScore())
+                .build();
+
+        AlbumReview review = AlbumReview.builder()
+                .score(5)
+                .build();
+
+        // when
+        statistics = statistics.updateReview(review, activityHistory, true);
+
+        // then
+        assertThat(statistics.getTotalActivityScore()).isEqualTo(-40);
+        assertThat(statistics.getTotalReview()).isEqualTo(0);
+        assertThat(statistics.getTotalReviewScore()).isEqualTo(0);
+    }
+
+    @Test
+    public void MemberStatistics는_평균을_계산할_수_있다() {
+        // given
+        int a = 25;
+        int b = 5;
+
+        // when
+        double average = MemberStatistics.empty().calculateAverage(a, b);
+
+        // then
+        assertThat(average).isEqualTo(5.0);
+    }
+}

--- a/src/test/java/com/project/singk/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/project/singk/domain/member/domain/MemberTest.java
@@ -24,8 +24,14 @@ class MemberTest {
 			.gender("MALE")
 			.build();
 
+        MemberStatistics statistics = MemberStatistics.empty();
+
 		// when
-		Member member = Member.from(memberCreate, new FakePasswordEncoderHolder("encodedPassword"));
+		Member member = Member.from(
+                memberCreate,
+                statistics,
+                new FakePasswordEncoderHolder("encodedPassword")
+        );
 
 		// then
 		assertAll(
@@ -129,4 +135,36 @@ class MemberTest {
 		assertThat(member.getGender()).isEqualTo(Gender.MALE);
 		assertThat(member.getRole()).isEqualTo(Role.ROLE_USER);
 	}
+
+    @Test
+    public void Member는_MemberStatistics를_수정할_수_있다() {
+        // given
+
+        Member member = Member.builder()
+                .id(1L)
+                .email("singk@gmail.com")
+                .password("encodedPassword")
+                .name("김철수")
+                .nickname("SingK")
+                .birthday(LocalDate.of(1999, 12, 30).atStartOfDay())
+                .gender(Gender.MALE)
+                .role(Role.ROLE_USER)
+                .build();
+
+        MemberStatistics statistics = MemberStatistics.builder()
+                .totalActivityScore(50)
+                .totalReview(1)
+                .totalReviewScore(5)
+                .build();
+
+        // when
+        member = member.updateStatistic(statistics);
+
+        // then
+
+        assertThat(member.getStatistics()).isNotNull();
+        assertThat(member.getStatistics().getTotalActivityScore()).isEqualTo(50);
+        assertThat(member.getStatistics().getTotalReview()).isEqualTo(1);
+        assertThat(member.getStatistics().getTotalReviewScore()).isEqualTo(5);
+    }
 }

--- a/src/test/java/com/project/singk/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/project/singk/domain/member/service/MemberServiceTest.java
@@ -5,16 +5,13 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
 
+import com.project.singk.domain.member.domain.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 
 import com.project.singk.domain.member.controller.response.MyProfileResponse;
-import com.project.singk.domain.member.domain.Gender;
-import com.project.singk.domain.member.domain.Member;
-import com.project.singk.domain.member.domain.MemberUpdate;
-import com.project.singk.domain.member.domain.Role;
 import com.project.singk.global.api.ApiException;
 import com.project.singk.global.api.AppHttpStatus;
 import com.project.singk.global.domain.PkResponseDto;
@@ -36,6 +33,7 @@ class MemberServiceTest {
 			.birthday(LocalDate.of(1999, 12, 30).atStartOfDay())
 			.gender(Gender.MALE)
 			.role(Role.ROLE_USER)
+            .statistics(MemberStatistics.empty())
 			.build());
 	}
 

--- a/src/test/java/com/project/singk/domain/review/controller/response/AlbumReviewResponseTest.java
+++ b/src/test/java/com/project/singk/domain/review/controller/response/AlbumReviewResponseTest.java
@@ -2,6 +2,7 @@ package com.project.singk.domain.review.controller.response;
 
 import com.project.singk.domain.member.domain.Gender;
 import com.project.singk.domain.member.domain.Member;
+import com.project.singk.domain.member.domain.MemberStatistics;
 import com.project.singk.domain.review.domain.AlbumReview;
 import org.junit.jupiter.api.Test;
 
@@ -19,6 +20,7 @@ class AlbumReviewResponseTest {
                 .id(1L)
                 .nickname("SingK")
                 .gender(Gender.MALE)
+                .statistics(MemberStatistics.empty())
                 .build();
 
         String imageUrl = "imageUrl";

--- a/src/test/java/com/project/singk/domain/review/domain/AlbumReviewStatisticsTest.java
+++ b/src/test/java/com/project/singk/domain/review/domain/AlbumReviewStatisticsTest.java
@@ -2,6 +2,7 @@ package com.project.singk.domain.review.domain;
 
 import com.project.singk.domain.member.domain.Gender;
 import com.project.singk.domain.member.domain.Member;
+import com.project.singk.domain.member.domain.MemberStatistics;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -107,5 +108,16 @@ class AlbumReviewStatisticsTest {
         assertThat(statistics.getFemaleCount()).isEqualTo(0);
         assertThat(statistics.getFemaleTotalScore()).isEqualTo(0);
     }
+    @Test
+    public void AlbumReviewStatistics는_평균을_계산할_수_있다() {
+        // given
+        int a = 25;
+        int b = 5;
 
+        // when
+        double average = AlbumReviewStatistics.empty().calculateAverage(a, b);
+
+        // then
+        assertThat(average).isEqualTo(5.0);
+    }
 }

--- a/src/test/java/com/project/singk/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/project/singk/domain/review/service/ReviewServiceTest.java
@@ -4,6 +4,7 @@ import com.project.singk.domain.album.domain.Album;
 import com.project.singk.domain.album.domain.AlbumType;
 import com.project.singk.domain.member.domain.Gender;
 import com.project.singk.domain.member.domain.Member;
+import com.project.singk.domain.member.domain.MemberStatistics;
 import com.project.singk.domain.member.domain.Role;
 import com.project.singk.domain.review.controller.response.AlbumReviewResponse;
 import com.project.singk.domain.review.controller.response.AlbumReviewStatisticsResponse;
@@ -42,6 +43,7 @@ class ReviewServiceTest {
                 .birthday(LocalDate.of(1999, 12, 30).atStartOfDay())
                 .gender(Gender.MALE)
                 .role(Role.ROLE_USER)
+                .statistics(MemberStatistics.empty())
                 .build());
         testContainer.albumRepository.save(Album.builder()
                 .id("0EhZEM4RRz0yioTgucDhJq")
@@ -139,6 +141,7 @@ class ReviewServiceTest {
                     .id(i)
                     .nickname("닉네임" + i)
                     .gender(i % 2 == 0 ? Gender.MALE : Gender.FEMALE)
+                    .statistics(MemberStatistics.empty())
                     .build());
         }
         tc.memberRepository.saveAll(members);
@@ -181,6 +184,7 @@ class ReviewServiceTest {
                     .id(i)
                     .nickname("닉네임" + i)
                     .gender(i % 2 == 0 ? Gender.MALE : Gender.FEMALE)
+                    .statistics(MemberStatistics.empty())
                     .build());
         }
         tc.memberRepository.saveAll(members);

--- a/src/test/java/com/project/singk/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/project/singk/domain/review/service/ReviewServiceTest.java
@@ -8,11 +8,13 @@ import com.project.singk.domain.member.domain.MemberStatistics;
 import com.project.singk.domain.member.domain.Role;
 import com.project.singk.domain.review.controller.response.AlbumReviewResponse;
 import com.project.singk.domain.review.controller.response.AlbumReviewStatisticsResponse;
+import com.project.singk.domain.review.controller.response.MyAlbumReviewResponse;
 import com.project.singk.domain.review.domain.AlbumReview;
 import com.project.singk.domain.review.domain.AlbumReviewCreate;
 import com.project.singk.domain.review.domain.AlbumReviewStatistics;
 import com.project.singk.global.api.ApiException;
 import com.project.singk.global.api.AppHttpStatus;
+import com.project.singk.global.api.PageResponse;
 import com.project.singk.global.domain.PkResponseDto;
 import com.project.singk.mock.TestContainer;
 import org.junit.jupiter.api.BeforeEach;
@@ -132,11 +134,11 @@ class ReviewServiceTest {
     }
 
     @Test
-    public void AlbumReview_목록을_최신순으로_조회할_수_있다() {
+    public void AlbumId로_AlbumReview_목록을_최신순으로_조회할_수_있다() {
         // given
         TestContainer tc = TestContainer.builder().build();
         List<Member> members = new ArrayList<>();
-        for (long i = 1L; i <= 5L; i++) {
+        for (long i = 1L; i <= 10L; i++) {
             members.add(Member.builder()
                     .id(i)
                     .nickname("닉네임" + i)
@@ -150,36 +152,38 @@ class ReviewServiceTest {
                 .build());
 
         List<AlbumReview> albumReviews = new ArrayList<>();
-        for (int i = 5; i >= 1; i--) {
+        for (int i = 10; i >= 1; i--) {
             albumReviews.add(AlbumReview.builder()
                     .id((long) i)
                     .content("감상평 내용입니다." + i)
                     .score(i)
                     .prosCount(i)
                     .consCount(0)
-                    .createdAt(LocalDateTime.of(2024, 6, 6, 0, 0, i))
-                    .reviewer(members.get(5 - i))
+                    .createdAt(LocalDateTime.of(2024, 6, i, 0, 0, 0))
+                    .reviewer(members.get(10 - i))
                     .album(album)
                     .build());
         }
         albumReviews = tc.albumReviewRepository.saveAll(albumReviews);
 
         // when
-        List<AlbumReviewResponse> result = tc.reviewService.getAlbumReviews("0EhZEM4RRz0yioTgucDhJq", "NEW");
+        PageResponse<AlbumReviewResponse> result = tc.reviewService.getAlbumReviews("0EhZEM4RRz0yioTgucDhJq", 0, 5,"NEW");
 
         // then
         assertAll(
-                () -> assertThat(result.get(0).getCreatedAt()).isEqualTo(LocalDateTime.of(2024, 6, 6, 0, 0, 5)),
-                () -> assertThat(result.get(0).getReviewer().getId()).isEqualTo(1L)
+                () -> assertThat(result.getOffset()).isEqualTo(0),
+                () -> assertThat(result.getLimit()).isEqualTo(5),
+                () -> assertThat(result.getTotal()).isEqualTo(10),
+                () -> assertThat(result.getItems().get(0).getCreatedAt()).isEqualTo(LocalDateTime.of(2024,6,10,0,0, 0))
         );
     }
 
     @Test
-    public void AlbumReview_목록을_공감순으로_조회할_수_있다() {
+    public void AlbumId로_AlbumReview_목록을_공감순으로_조회할_수_있다() {
         // given
         TestContainer tc = TestContainer.builder().build();
         List<Member> members = new ArrayList<>();
-        for (long i = 1L; i <= 5L; i++) {
+        for (long i = 1L; i <= 10L; i++) {
             members.add(Member.builder()
                     .id(i)
                     .nickname("닉네임" + i)
@@ -193,7 +197,7 @@ class ReviewServiceTest {
                 .build());
 
         List<AlbumReview> albumReviews = new ArrayList<>();
-        for (int i = 1; i <= 5; i++) {
+        for (int i = 1; i <= 10; i++) {
             albumReviews.add(AlbumReview.builder()
                     .id((long) i)
                     .content("감상평 내용입니다." + i)
@@ -208,12 +212,14 @@ class ReviewServiceTest {
         albumReviews = tc.albumReviewRepository.saveAll(albumReviews);
 
         // when
-        List<AlbumReviewResponse> result = tc.reviewService.getAlbumReviews("0EhZEM4RRz0yioTgucDhJq", "LIKES");
+        PageResponse<AlbumReviewResponse> result = tc.reviewService.getAlbumReviews("0EhZEM4RRz0yioTgucDhJq",0, 5, "LIKES");
 
         // then
         assertAll(
-                () -> assertThat(result.get(0).getPros()).isEqualTo(5),
-                () -> assertThat(result.get(0).getReviewer().getId()).isEqualTo(5L)
+                () -> assertThat(result.getOffset()).isEqualTo(0),
+                () -> assertThat(result.getLimit()).isEqualTo(5),
+                () -> assertThat(result.getTotal()).isEqualTo(10),
+                () -> assertThat(result.getItems().get(0).getPros()).isEqualTo(10)
         );
     }
 
@@ -247,6 +253,118 @@ class ReviewServiceTest {
                 () -> assertThat(result.getScoreStatistics().get(0).getRatio()).isEqualTo(0.0),
                 () -> assertThat(result.getGenderStatistics().get(0).getAverageScore()).isEqualTo(0.0),
                 () -> assertThat(result.getGenderStatistics().get(0).getRatio()).isEqualTo(0.0)
+        );
+    }
+
+    @Test
+    public void MemberId로_AlbumReview_목록을_최신순으로_조회할_수_있다() {
+        // given
+        TestContainer tc = TestContainer.builder().build();
+        Member member1 = tc.memberRepository.save(Member.builder()
+                .id(1L)
+                .nickname("SingK1")
+                .gender(Gender.MALE)
+                .statistics(MemberStatistics.empty())
+                .build());
+        Member member2 = tc.memberRepository.save(Member.builder()
+                .id(2L)
+                .nickname("SingK2")
+                .gender(Gender.FEMALE)
+                .statistics(MemberStatistics.empty())
+                .build());
+
+        List<Album> albums = new ArrayList<>();
+        for (long i = 1; i <= 20; i++) {
+            albums.add(Album.builder()
+                    .id("0EhZEM4RRz0yioTgucDhJq" + i)
+                    .tracks(new ArrayList<>())
+                    .artists(new ArrayList<>())
+                    .images(new ArrayList<>())
+                    .build());
+        }
+        tc.albumRepository.saveAll(albums);
+
+
+        List<AlbumReview> albumReviews = new ArrayList<>();
+        for (int i = 1; i <= 20; i++) {
+            albumReviews.add(AlbumReview.builder()
+                    .id((long) i)
+                    .content("감상평 내용입니다." + i)
+                    .score(i)
+                    .prosCount(i)
+                    .consCount(0)
+                    .createdAt(LocalDateTime.of(2024, 6, i, 0, 0, 0))
+                    .reviewer(i % 2 == 0 ? member1 : member2)
+                    .album(albums.get(i - 1))
+                    .build());
+        }
+        albumReviews = tc.albumReviewRepository.saveAll(albumReviews);
+
+        // when
+        PageResponse<MyAlbumReviewResponse> result = tc.reviewService.getMyAlbumReview(1L, 0, 5,"NEW");
+
+        // then
+        assertAll(
+                () -> assertThat(result.getOffset()).isEqualTo(0),
+                () -> assertThat(result.getLimit()).isEqualTo(5),
+                () -> assertThat(result.getTotal()).isEqualTo(10),
+                () -> assertThat(result.getItems().get(0).getCreatedAt()).isEqualTo(LocalDateTime.of(2024,6,20,0,0, 0))
+        );
+    }
+
+    @Test
+    public void MemberId로_AlbumReview_목록을_공감순으로_조회할_수_있다() {
+        // given
+        TestContainer tc = TestContainer.builder().build();
+        Member member1 = tc.memberRepository.save(Member.builder()
+                .id(1L)
+                .nickname("SingK1")
+                .gender(Gender.MALE)
+                .statistics(MemberStatistics.empty())
+                .build());
+        Member member2 = tc.memberRepository.save(Member.builder()
+                .id(2L)
+                .nickname("SingK2")
+                .gender(Gender.FEMALE)
+                .statistics(MemberStatistics.empty())
+                .build());
+
+        List<Album> albums = new ArrayList<>();
+        for (long i = 1; i <= 20; i++) {
+            albums.add(Album.builder()
+                    .id("0EhZEM4RRz0yioTgucDhJq" + i)
+                    .tracks(new ArrayList<>())
+                    .artists(new ArrayList<>())
+                    .images(new ArrayList<>())
+                    .build());
+        }
+        tc.albumRepository.saveAll(albums);
+
+
+        List<AlbumReview> albumReviews = new ArrayList<>();
+        for (int i = 1; i <= 20; i++) {
+            albumReviews.add(AlbumReview.builder()
+                    .id((long) i)
+                    .content("감상평 내용입니다." + i)
+                    .score(i)
+                    .prosCount(i)
+                    .consCount(0)
+                    .createdAt(LocalDateTime.of(2024, 6, i, 0, 0, 0))
+                    .reviewer(i % 2 == 0 ? member1 : member2)
+                    .album(albums.get(i - 1))
+                    .build());
+        }
+        albumReviews = tc.albumReviewRepository.saveAll(albumReviews);
+
+        // when
+        PageResponse<MyAlbumReviewResponse> result = tc.reviewService.getMyAlbumReview(1L, 0, 5,"LIKES");
+
+        // then
+        assertAll(
+                () -> assertThat(result.getOffset()).isEqualTo(0),
+                () -> assertThat(result.getLimit()).isEqualTo(5),
+                () -> assertThat(result.getTotal()).isEqualTo(10),
+                () -> assertThat(result.getItems().get(0).getPros()).isEqualTo(20)
         );
     }
 }

--- a/src/test/java/com/project/singk/domain/vote/service/VoteServiceTest.java
+++ b/src/test/java/com/project/singk/domain/vote/service/VoteServiceTest.java
@@ -2,6 +2,7 @@ package com.project.singk.domain.vote.service;
 
 import com.project.singk.domain.album.domain.Album;
 import com.project.singk.domain.member.domain.Member;
+import com.project.singk.domain.member.domain.MemberStatistics;
 import com.project.singk.domain.review.domain.AlbumReview;
 import com.project.singk.domain.vote.domain.AlbumReviewVote;
 import com.project.singk.domain.vote.domain.VoteCreate;
@@ -28,11 +29,14 @@ class VoteServiceTest {
         List<Member> members = testContainer.memberRepository.saveAll(List.of(
                 Member.builder()
                         .id(1L)
+                        .statistics(MemberStatistics.empty())
                         .build(),
                 Member.builder()
                         .id(2L)
+                        .statistics(MemberStatistics.empty())
                         .build()
         ));
+
         Album album = testContainer.albumRepository.save(Album.builder()
                 .id("0EhZEM4RRz0yioTgucDhJq")
                 .build());

--- a/src/test/java/com/project/singk/mock/FakeActivityHistoryRepository.java
+++ b/src/test/java/com/project/singk/mock/FakeActivityHistoryRepository.java
@@ -1,0 +1,21 @@
+package com.project.singk.mock;
+
+import com.project.singk.domain.activity.domain.ActivityHistory;
+import com.project.singk.domain.activity.service.port.ActivityHistoryRepository;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public class FakeActivityHistoryRepository implements ActivityHistoryRepository {
+	private final List<ActivityHistory> data = Collections.synchronizedList(new ArrayList<>());
+
+    @Override
+    public ActivityHistory save(ActivityHistory activityHistory) {
+        data.removeIf(item -> Objects.equals(item.getId(), activityHistory.getId()));
+        data.add(activityHistory);
+        return activityHistory;
+    }
+
+}

--- a/src/test/java/com/project/singk/mock/TestContainer.java
+++ b/src/test/java/com/project/singk/mock/TestContainer.java
@@ -1,5 +1,7 @@
 package com.project.singk.mock;
 
+import com.project.singk.domain.activity.domain.ActivityHistory;
+import com.project.singk.domain.activity.service.port.ActivityHistoryRepository;
 import com.project.singk.domain.album.controller.port.AlbumService;
 import com.project.singk.domain.album.service.AlbumServiceImpl;
 import com.project.singk.domain.album.service.port.*;
@@ -35,6 +37,7 @@ public class TestContainer {
     public final AlbumImageRepository albumImageRepository;
     public final AlbumReviewRepository albumReviewRepository;
     public final AlbumReviewVoteRepository albumReviewVoteRepository;
+    public final ActivityHistoryRepository activityHistoryRepository;
     public final SpotifyRepository spotifyRepository;
 	public final S3Repository s3Repository;
 	public final RedisRepository redisRepository;
@@ -56,6 +59,7 @@ public class TestContainer {
         this.albumImageRepository = new FakeAlbumImageRepository();
         this.albumReviewRepository = new FakeAlbumReviewRepository();
         this.albumReviewVoteRepository = new FakeAlbumReviewVoteRepository();
+        this.activityHistoryRepository = new FakeActivityHistoryRepository();
         this.spotifyRepository = new FakeSpotifyRepository();
 		this.s3Repository = new FakeS3Repository();
 		this.redisRepository = new FakeRedisRepository();
@@ -83,6 +87,7 @@ public class TestContainer {
         this.reviewService = ReviewServiceImpl.builder()
                 .albumReviewRepository(this.albumReviewRepository)
                 .albumRepository(this.albumRepository)
+                .activityHistoryRepository(this.activityHistoryRepository)
                 .memberRepository(this.memberRepository)
                 .s3Repository(this.s3Repository)
                 .build();

--- a/src/test/java/com/project/singk/mock/TestContainer.java
+++ b/src/test/java/com/project/singk/mock/TestContainer.java
@@ -95,6 +95,7 @@ public class TestContainer {
                 .albumReviewVoteRepository(this.albumReviewVoteRepository)
                 .memberRepository(this.memberRepository)
                 .albumReviewRepository(this.albumReviewRepository)
+                .activityHistoryRepository(this.activityHistoryRepository)
                 .build();
 	}
 


### PR DESCRIPTION
## 구현 내용
- 앨범 감상평 작성, 공감, 삭제 시 활동 히스토리 반영
- 회원 통계 (e.g. 리뷰 개수, 리뷰 총점, 총 활동 지수) 를 위한 테이블 분리
- 내가 작성한 감상평 목록 조회 기능 구현
- 테스트 코드 작성
- 그 외 성능 개선