### PR TITLE
앨범 아티스트 PK 수정 및 어드민 API 구현

### DIFF
--- a/src/main/generated/com/project/singk/domain/album/infrastructure/entity/QAlbumArtistEntity.java
+++ b/src/main/generated/com/project/singk/domain/album/infrastructure/entity/QAlbumArtistEntity.java
@@ -1,0 +1,59 @@
+package com.project.singk.domain.album.infrastructure.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QAlbumArtistEntity is a Querydsl query type for AlbumArtistEntity
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QAlbumArtistEntity extends EntityPathBase<AlbumArtistEntity> {
+
+    private static final long serialVersionUID = 102965476L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QAlbumArtistEntity albumArtistEntity = new QAlbumArtistEntity("albumArtistEntity");
+
+    public final com.project.singk.global.domain.QBaseTimeEntity _super = new com.project.singk.global.domain.QBaseTimeEntity(this);
+
+    public final QArtistEntity artist;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public QAlbumArtistEntity(String variable) {
+        this(AlbumArtistEntity.class, forVariable(variable), INITS);
+    }
+
+    public QAlbumArtistEntity(Path<? extends AlbumArtistEntity> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QAlbumArtistEntity(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QAlbumArtistEntity(PathMetadata metadata, PathInits inits) {
+        this(AlbumArtistEntity.class, metadata, inits);
+    }
+
+    public QAlbumArtistEntity(Class<? extends AlbumArtistEntity> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.artist = inits.isInitialized("artist") ? new QArtistEntity(forProperty("artist")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/project/singk/domain/album/infrastructure/entity/QAlbumEntity.java
+++ b/src/main/generated/com/project/singk/domain/album/infrastructure/entity/QAlbumEntity.java
@@ -24,7 +24,7 @@ public class QAlbumEntity extends EntityPathBase<AlbumEntity> {
 
     public final com.project.singk.global.domain.QBaseTimeEntity _super = new com.project.singk.global.domain.QBaseTimeEntity(this);
 
-    public final ListPath<ArtistEntity, QArtistEntity> artists = this.<ArtistEntity, QArtistEntity>createList("artists", ArtistEntity.class, QArtistEntity.class, PathInits.DIRECT2);
+    public final ListPath<AlbumArtistEntity, QAlbumArtistEntity> artists = this.<AlbumArtistEntity, QAlbumArtistEntity>createList("artists", AlbumArtistEntity.class, QAlbumArtistEntity.class, PathInits.DIRECT2);
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;

--- a/src/main/java/com/project/singk/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/project/singk/domain/admin/controller/AdminController.java
@@ -1,0 +1,36 @@
+package com.project.singk.domain.admin.controller;
+
+import com.project.singk.domain.admin.controller.port.AdminService;
+import com.project.singk.domain.album.controller.response.AlbumDetailResponse;
+import com.project.singk.global.api.BaseResponse;
+import com.project.singk.global.api.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.constraints.Range;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/")
+public class AdminController {
+
+	private final AdminService adminService;
+
+	@PostMapping("/create/albums")
+	public BaseResponse<PageResponse<AlbumDetailResponse>> createAlbums(
+		@RequestParam(value = "query", required = false) String query,
+		@Range(min = 0, max = 1000, message = "offset은 0에서 1000사이의 값 이어야 합니다.") @RequestParam("offset") int offset,
+		@Range(min = 0, max = 50, message = "limit은 0에서 50사이의 값 이어야 합니다.") @RequestParam("limit") int limit
+	) {
+		return BaseResponse.ok(adminService.createAlbums(query, offset, limit));
+	}
+
+    @DeleteMapping("/delete/members/{memberId}")
+    public BaseResponse<Void> deleteMember(
+            @PathVariable(name = "memberId") Long memberId
+    ) {
+        adminService.deleteMember(memberId);
+        return BaseResponse.ok();
+    }
+}

--- a/src/main/java/com/project/singk/domain/admin/controller/port/AdminService.java
+++ b/src/main/java/com/project/singk/domain/admin/controller/port/AdminService.java
@@ -1,0 +1,9 @@
+package com.project.singk.domain.admin.controller.port;
+
+import com.project.singk.domain.album.controller.response.AlbumDetailResponse;
+import com.project.singk.global.api.PageResponse;
+
+public interface AdminService {
+    PageResponse<AlbumDetailResponse> createAlbums(String query, int offset, int limit);
+    void deleteMember(Long memberId);
+}

--- a/src/main/java/com/project/singk/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/project/singk/domain/admin/service/AdminServiceImpl.java
@@ -1,0 +1,71 @@
+package com.project.singk.domain.admin.service;
+
+import com.project.singk.domain.admin.controller.port.AdminService;
+import com.project.singk.domain.album.controller.response.AlbumDetailResponse;
+import com.project.singk.domain.album.domain.Album;
+import com.project.singk.domain.album.domain.AlbumArtist;
+import com.project.singk.domain.album.infrastructure.spotify.AlbumSimplifiedEntity;
+import com.project.singk.domain.album.service.port.*;
+import com.project.singk.domain.member.service.port.MemberRepository;
+import com.project.singk.domain.review.domain.AlbumReviewStatistics;
+import com.project.singk.global.api.PageResponse;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Builder
+@RequiredArgsConstructor
+@Transactional
+public class AdminServiceImpl implements AdminService {
+
+    private final SpotifyRepository spotifyRepository;
+    private final AlbumRepository albumRepository;
+    private final ArtistRepository artistRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public PageResponse<AlbumDetailResponse> createAlbums(String query, int offset, int limit) {
+
+        PageResponse<AlbumSimplifiedEntity> spotifyAlbums = spotifyRepository.searchAlbums(query, offset, limit);
+
+        List<AlbumDetailResponse> albums = spotifyAlbums.getItems().stream()
+                .map(spotifyAlbum -> {
+                    Album album = spotifyRepository.getAlbumById(spotifyAlbum.getId()).toModel();
+
+                    // 앨범 통게 생성
+                    AlbumReviewStatistics statistics = AlbumReviewStatistics.empty();
+                    album = album.updateStatistic(statistics);
+
+                    if (albumRepository.existsById(spotifyAlbum.getId())) return AlbumDetailResponse.from(album);
+
+                    // 아티스트 생성
+                    for (AlbumArtist artist : album.getArtists()) {
+
+                        if (!artistRepository.existById(artist.getArtist().getId())) {
+                            artistRepository.save(artist.getArtist());
+                        }
+                    }
+
+                    album = albumRepository.save(album);
+
+                    return AlbumDetailResponse.from(album);
+                })
+                .toList();
+
+        return PageResponse.of(
+                offset,
+                limit,
+                spotifyAlbums.getTotal(),
+                albums
+        );
+    }
+
+    @Override
+    public void deleteMember(Long memberId) {
+        memberRepository.deleteById(memberId);
+    }
+}

--- a/src/main/java/com/project/singk/domain/album/controller/response/AlbumDetailResponse.java
+++ b/src/main/java/com/project/singk/domain/album/controller/response/AlbumDetailResponse.java
@@ -6,9 +6,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.project.singk.domain.album.domain.Album;
 
-import com.project.singk.domain.album.domain.AlbumImage;
-import com.project.singk.domain.album.domain.Artist;
-import com.project.singk.domain.album.domain.Track;
+import com.project.singk.domain.album.domain.AlbumArtist;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -34,9 +32,16 @@ public class AlbumDetailResponse {
             .type(album.getType().getName())
 			.releasedAt(album.getReleasedAt())
 			.trackCount(album.getTracks().size())
-			.tracks(album.getTracks().stream().map(TrackResponse::from).toList())
-			.images(album.getImages().stream().map(ImageResponse::from).toList())
-			.artists(album.getArtists().stream().map(ArtistResponse::from).toList())
+			.tracks(album.getTracks().stream()
+                    .map(TrackResponse::from)
+                    .toList())
+			.images(album.getImages().stream()
+                    .map(ImageResponse::from)
+                    .toList())
+			.artists(album.getArtists().stream()
+                    .map(AlbumArtist::getArtist)
+                    .map(ArtistResponse::from)
+                    .toList())
 			.build();
 	}
 }

--- a/src/main/java/com/project/singk/domain/album/controller/response/AlbumListResponse.java
+++ b/src/main/java/com/project/singk/domain/album/controller/response/AlbumListResponse.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.project.singk.domain.album.domain.Album;
 
+import com.project.singk.domain.album.domain.AlbumArtist;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -31,6 +32,7 @@ public class AlbumListResponse {
 			.name(album.getName())
 			.releasedAt(album.getReleasedAt())
 			.artists(album.getArtists().stream()
+                .map(AlbumArtist::getArtist)
 				.map(ArtistResponse::from)
 				.toList())
 			.images(album.getImages().stream()

--- a/src/main/java/com/project/singk/domain/album/controller/response/AlbumSimpleResponse.java
+++ b/src/main/java/com/project/singk/domain/album/controller/response/AlbumSimpleResponse.java
@@ -1,6 +1,7 @@
 package com.project.singk.domain.album.controller.response;
 
 import com.project.singk.domain.album.domain.Album;
+import com.project.singk.domain.album.domain.AlbumArtist;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -22,6 +23,7 @@ public class AlbumSimpleResponse {
                 .id(album.getId())
                 .name(album.getName())
                 .artists(album.getArtists().stream()
+                        .map(AlbumArtist::getArtist)
                         .map(ArtistResponse::from)
                         .toList())
                 .images(album.getImages().stream()

--- a/src/main/java/com/project/singk/domain/album/domain/Album.java
+++ b/src/main/java/com/project/singk/domain/album/domain/Album.java
@@ -14,12 +14,12 @@ public class Album {
 	private final AlbumType type;
 	private final LocalDateTime releasedAt;
     private final List<Track> tracks;
-    private final List<Artist> artists;
+    private final List<AlbumArtist> artists;
     private final List<AlbumImage> images;
     private final AlbumReviewStatistics statistics;
     private final LocalDateTime createdAt;
     @Builder
-    public Album(String id, String name, AlbumType type, LocalDateTime releasedAt, List<Track> tracks, List<Artist> artists, List<AlbumImage> images, AlbumReviewStatistics statistics, LocalDateTime createdAt) {
+    public Album(String id, String name, AlbumType type, LocalDateTime releasedAt, List<Track> tracks, List<AlbumArtist> artists, List<AlbumImage> images, AlbumReviewStatistics statistics, LocalDateTime createdAt) {
         this.id = id;
         this.name = name;
         this.type = type;

--- a/src/main/java/com/project/singk/domain/album/domain/AlbumArtist.java
+++ b/src/main/java/com/project/singk/domain/album/domain/AlbumArtist.java
@@ -1,0 +1,22 @@
+package com.project.singk.domain.album.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AlbumArtist {
+    private final Long id;
+    private final Artist artist;
+
+    @Builder
+    public AlbumArtist(Long id, Artist artist) {
+        this.id = id;
+        this.artist = artist;
+    }
+
+    public static AlbumArtist from (Artist artist) {
+        return AlbumArtist.builder()
+                .artist(artist)
+                .build();
+    }
+}

--- a/src/main/java/com/project/singk/domain/album/infrastructure/AlbumRepositoryImpl.java
+++ b/src/main/java/com/project/singk/domain/album/infrastructure/AlbumRepositoryImpl.java
@@ -47,6 +47,11 @@ public class AlbumRepositoryImpl implements AlbumRepository {
     }
 
     @Override
+    public boolean existsById(String albumId) {
+        return albumJpaRepository.existsById(albumId);
+    }
+
+    @Override
 	public Album getById(String id) {
 		return findById(id)
 			.orElseThrow(() -> new ApiException(AppHttpStatus.NOT_FOUND_ALBUM));

--- a/src/main/java/com/project/singk/domain/album/infrastructure/AlbumRepositoryImpl.java
+++ b/src/main/java/com/project/singk/domain/album/infrastructure/AlbumRepositoryImpl.java
@@ -24,9 +24,9 @@ import com.project.singk.global.api.AppHttpStatus;
 
 import lombok.RequiredArgsConstructor;
 
+import static com.project.singk.domain.album.infrastructure.entity.QAlbumArtistEntity.albumArtistEntity;
 import static com.project.singk.domain.album.infrastructure.entity.QAlbumEntity.albumEntity;
 import static com.project.singk.domain.album.infrastructure.entity.QAlbumImageEntity.albumImageEntity;
-import static com.project.singk.domain.album.infrastructure.entity.QArtistEntity.artistEntity;
 import static com.project.singk.domain.album.infrastructure.entity.QTrackEntity.trackEntity;
 import static com.project.singk.domain.review.infrastructure.QAlbumReviewStatisticsEntity.albumReviewStatisticsEntity;
 
@@ -63,7 +63,7 @@ public class AlbumRepositoryImpl implements AlbumRepository {
 
         return jpaQueryFactory.select(albumReviewStatisticsEntity)
                 .from(albumEntity)
-                .leftJoin(albumEntity.statistics, albumReviewStatisticsEntity)
+                .innerJoin(albumEntity.statistics, albumReviewStatisticsEntity)
                 .where(albumEntity.id.eq(albumId))
                 .fetchOne()
                 .toModel();
@@ -72,9 +72,9 @@ public class AlbumRepositoryImpl implements AlbumRepository {
     @Override
     public Optional<Album> findByIdWithStatistics(String albumId) {
         return Optional.ofNullable(jpaQueryFactory.select(albumEntity)
-                .from(albumEntity).fetchJoin()
+                .from(albumEntity)
                 .where(albumEntity.id.eq(albumId))
-                .innerJoin(albumEntity.statistics, albumReviewStatisticsEntity)
+                .innerJoin(albumEntity.statistics, albumReviewStatisticsEntity).fetchJoin()
                 .fetchOne())
                 .map(AlbumEntity::toModel);
     }
@@ -82,12 +82,11 @@ public class AlbumRepositoryImpl implements AlbumRepository {
     @Override
 	public Optional<Album> findById(String id) {
         return Optional.ofNullable(jpaQueryFactory
-                .select(albumEntity)
-                .from(albumEntity)
+                .selectFrom(albumEntity)
                 .where(albumEntity.id.eq(id))
-                .innerJoin(albumEntity.tracks, trackEntity)
-                .innerJoin(albumEntity.artists, artistEntity)
-                .innerJoin(albumEntity.images, albumImageEntity)
+                .leftJoin(albumEntity.tracks, trackEntity)
+                .leftJoin(albumEntity.images, albumImageEntity)
+                .leftJoin(albumEntity.artists, albumArtistEntity)
                 .fetchOne())
                 .map(AlbumEntity::toModel);
 	}

--- a/src/main/java/com/project/singk/domain/album/infrastructure/ArtistRepositoryImpl.java
+++ b/src/main/java/com/project/singk/domain/album/infrastructure/ArtistRepositoryImpl.java
@@ -27,4 +27,9 @@ public class ArtistRepositoryImpl implements ArtistRepository {
                 .map(ArtistEntity::toModel)
                 .toList();
     }
+
+    @Override
+    public boolean existById(String artistId) {
+        return artistJpaRepository.existsById(artistId);
+    }
 }

--- a/src/main/java/com/project/singk/domain/album/infrastructure/entity/AlbumArtistEntity.java
+++ b/src/main/java/com/project/singk/domain/album/infrastructure/entity/AlbumArtistEntity.java
@@ -1,0 +1,44 @@
+package com.project.singk.domain.album.infrastructure.entity;
+
+
+import com.project.singk.domain.album.domain.AlbumArtist;
+import com.project.singk.global.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "ALBUM_ARTISTS")
+@Getter
+@NoArgsConstructor
+public class AlbumArtistEntity extends BaseTimeEntity {
+
+	@Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "artist_id")
+    private ArtistEntity artist;
+
+    @Builder
+    public AlbumArtistEntity(Long id, ArtistEntity artist) {
+        this.id = id;
+        this.artist = artist;
+    }
+
+    public static AlbumArtistEntity from (AlbumArtist albumArtist) {
+        return AlbumArtistEntity.builder()
+                .id(albumArtist.getId())
+                .artist(ArtistEntity.from(albumArtist.getArtist()))
+                .build();
+    }
+
+    public AlbumArtist toModel() {
+        return AlbumArtist.builder()
+                .id(this.id)
+                .artist(this.artist.toModel())
+                .build();
+    }
+}

--- a/src/main/java/com/project/singk/domain/album/infrastructure/entity/AlbumEntity.java
+++ b/src/main/java/com/project/singk/domain/album/infrastructure/entity/AlbumEntity.java
@@ -40,11 +40,11 @@ public class AlbumEntity extends BaseTimeEntity implements Persistable<String> {
 
     @JoinColumn(name = "album_id", updatable = false, nullable = false)
     @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
-    private List<ArtistEntity> artists;
+    private List<AlbumImageEntity> images;
 
     @JoinColumn(name = "album_id", updatable = false, nullable = false)
     @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
-    private List<AlbumImageEntity> images;
+    private List<AlbumArtistEntity> artists;
 
     @JoinColumn(name = "statistic_id")
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
@@ -53,14 +53,14 @@ public class AlbumEntity extends BaseTimeEntity implements Persistable<String> {
     @Transient
     private LocalDateTime isNew;
     @Builder
-    public AlbumEntity(String id, String name, AlbumType type, LocalDateTime releasedAt, List<TrackEntity> tracks, List<ArtistEntity> artists, List<AlbumImageEntity> images, AlbumReviewStatisticsEntity statistics, LocalDateTime isNew) {
+    public AlbumEntity(String id, String name, AlbumType type, LocalDateTime releasedAt, List<TrackEntity> tracks, List<AlbumImageEntity> images, List<AlbumArtistEntity> artists, AlbumReviewStatisticsEntity statistics, LocalDateTime isNew) {
         this.id = id;
         this.name = name;
         this.type = type;
         this.releasedAt = releasedAt;
         this.tracks = tracks;
-        this.artists = artists;
         this.images = images;
+        this.artists = artists;
         this.statistics = statistics;
         this.isNew = isNew;
     }
@@ -72,8 +72,8 @@ public class AlbumEntity extends BaseTimeEntity implements Persistable<String> {
 			.type(album.getType())
 			.releasedAt(album.getReleasedAt())
             .tracks(album.getTracks().stream().map(TrackEntity::from).toList())
-            .artists(album.getArtists().stream().map(ArtistEntity::from).toList())
             .images(album.getImages().stream().map(AlbumImageEntity::from).toList())
+            .artists(album.getArtists().stream().map(AlbumArtistEntity::from).toList())
             .statistics(AlbumReviewStatisticsEntity.from(album.getStatistics()))
             .isNew(album.getCreatedAt())
 			.build();
@@ -86,8 +86,8 @@ public class AlbumEntity extends BaseTimeEntity implements Persistable<String> {
 			.type(this.type)
 			.releasedAt(this.releasedAt)
             .tracks(this.tracks.stream().map(TrackEntity::toModel).toList())
-            .artists(this.artists.stream().map(ArtistEntity::toModel).toList())
             .images(this.images.stream().map(AlbumImageEntity::toModel).toList())
+            .artists(this.artists.stream().map(AlbumArtistEntity::toModel).toList())
             .statistics(this.statistics.toModel())
             .createdAt(this.getCreatedAt())
 			.build();

--- a/src/main/java/com/project/singk/domain/album/infrastructure/entity/ArtistEntity.java
+++ b/src/main/java/com/project/singk/domain/album/infrastructure/entity/ArtistEntity.java
@@ -3,14 +3,13 @@ package com.project.singk.domain.album.infrastructure.entity;
 import com.project.singk.domain.album.domain.Artist;
 import com.project.singk.global.domain.BaseTimeEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Persistable;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "ARTISTS")
@@ -25,16 +24,21 @@ public class ArtistEntity extends BaseTimeEntity implements Persistable<String> 
 	@Column(name = "name")
 	private String name;
 
+    @Transient
+    private LocalDateTime isNew;
+
     @Builder
-    public ArtistEntity(String id, String name) {
+    public ArtistEntity(String id, String name, LocalDateTime isNew) {
         this.id = id;
         this.name = name;
+        this.isNew = isNew;
     }
 
 	public static ArtistEntity from(Artist artist) {
 		return ArtistEntity.builder()
 			.id(artist.getId())
 			.name(artist.getName())
+            .isNew(artist.getCreatedAt())
 			.build();
 	}
 
@@ -48,6 +52,6 @@ public class ArtistEntity extends BaseTimeEntity implements Persistable<String> 
 
     @Override
     public boolean isNew() {
-        return this.getCreatedAt() == null;
+        return this.getCreatedAt() == null && this.isNew == null;
     }
 }

--- a/src/main/java/com/project/singk/domain/album/infrastructure/spotify/AlbumEntity.java
+++ b/src/main/java/com/project/singk/domain/album/infrastructure/spotify/AlbumEntity.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.project.singk.domain.album.domain.Album;
+import com.project.singk.domain.album.domain.AlbumArtist;
 import com.project.singk.domain.album.domain.AlbumType;
 
 import lombok.Builder;
@@ -64,7 +65,10 @@ public class AlbumEntity {
                 .type(AlbumType.of(this.type, this.tracks.size()))
                 .releasedAt(this.releasedAt)
                 .tracks(this.tracks.stream().map(TrackSimplifiedEntity::toModel).toList())
-                .artists(this.artists.stream().map(ArtistSimplifiedEntity::toModel).toList())
+                .artists(this.artists.stream()
+                        .map(ArtistSimplifiedEntity::toModel)
+                        .map(AlbumArtist::from)
+                        .toList())
                 .images(this.images.stream().map(ImageEntity::toModel).toList())
                 .build();
     }

--- a/src/main/java/com/project/singk/domain/album/infrastructure/spotify/AlbumSimplifiedEntity.java
+++ b/src/main/java/com/project/singk/domain/album/infrastructure/spotify/AlbumSimplifiedEntity.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import com.project.singk.domain.album.domain.Album;
 
+import com.project.singk.domain.album.domain.AlbumArtist;
 import com.project.singk.domain.review.domain.AlbumReviewStatistics;
 import lombok.Builder;
 import lombok.Getter;
@@ -54,7 +55,10 @@ public class AlbumSimplifiedEntity {
 			.id(this.id)
 			.name(this.name)
 			.releasedAt(this.releasedAt)
-            .artists(this.artists.stream().map(ArtistSimplifiedEntity::toModel).toList())
+            .artists(this.artists.stream()
+                    .map(ArtistSimplifiedEntity::toModel)
+                    .map(AlbumArtist::from)
+                    .toList())
             .images(this.images.stream().map(ImageEntity::toModel).toList())
             .statistics(AlbumReviewStatistics.empty())
 			.build();

--- a/src/main/java/com/project/singk/domain/album/service/AlbumServiceImpl.java
+++ b/src/main/java/com/project/singk/domain/album/service/AlbumServiceImpl.java
@@ -1,8 +1,11 @@
 package com.project.singk.domain.album.service;
 
 import com.project.singk.domain.album.controller.request.AlbumSort;
+import com.project.singk.domain.album.domain.AlbumArtist;
+import com.project.singk.domain.album.domain.Artist;
 import com.project.singk.domain.album.infrastructure.spotify.*;
 import com.project.singk.domain.album.service.port.*;
+import com.project.singk.domain.review.domain.AlbumReview;
 import com.project.singk.domain.review.domain.AlbumReviewStatistics;
 import com.project.singk.global.api.PageResponse;
 import lombok.Builder;
@@ -38,9 +41,21 @@ public class AlbumServiceImpl implements AlbumService {
 		}
 
 		AlbumEntity spotifyAlbum = spotifyRepository.getAlbumById(albumId);
+
+        // 앨범 통계 생성
         AlbumReviewStatistics statistics = AlbumReviewStatistics.empty();
         album = spotifyAlbum.toModel();
+
         album = album.updateStatistic(statistics);
+
+        // 아티스트 생성
+        for (AlbumArtist artist : album.getArtists()) {
+            System.out.println(artist.getArtist().getName());
+            if (!artistRepository.existById(artist.getArtist().getId())) {
+                artistRepository.save(artist.getArtist());
+            }
+        }
+
         album = albumRepository.save(album);
 
 		return AlbumDetailResponse.from(album);

--- a/src/main/java/com/project/singk/domain/album/service/AlbumServiceImpl.java
+++ b/src/main/java/com/project/singk/domain/album/service/AlbumServiceImpl.java
@@ -1,11 +1,8 @@
 package com.project.singk.domain.album.service;
 
-import com.project.singk.domain.album.controller.request.AlbumSort;
 import com.project.singk.domain.album.domain.AlbumArtist;
-import com.project.singk.domain.album.domain.Artist;
 import com.project.singk.domain.album.infrastructure.spotify.*;
 import com.project.singk.domain.album.service.port.*;
-import com.project.singk.domain.review.domain.AlbumReview;
 import com.project.singk.domain.review.domain.AlbumReviewStatistics;
 import com.project.singk.global.api.PageResponse;
 import lombok.Builder;
@@ -50,7 +47,7 @@ public class AlbumServiceImpl implements AlbumService {
 
         // 아티스트 생성
         for (AlbumArtist artist : album.getArtists()) {
-            System.out.println(artist.getArtist().getName());
+
             if (!artistRepository.existById(artist.getArtist().getId())) {
                 artistRepository.save(artist.getArtist());
             }

--- a/src/main/java/com/project/singk/domain/album/service/port/AlbumRepository.java
+++ b/src/main/java/com/project/singk/domain/album/service/port/AlbumRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page;
 public interface AlbumRepository {
 	Album save(Album album);
     List<Album> saveAll(List<Album> albums);
+    boolean existsById(String albumId);
 	Album getById(String albumId);
     Album getByIdWithStatistics(String albumId);
     AlbumReviewStatistics getAlbumReviewStatisticsByAlbumId(String albumId);

--- a/src/main/java/com/project/singk/domain/album/service/port/ArtistRepository.java
+++ b/src/main/java/com/project/singk/domain/album/service/port/ArtistRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 public interface ArtistRepository {
     Artist save(Artist artist);
     List<Artist> saveAll(List<Artist> artists);
+    boolean existById(String artistId);
 }

--- a/src/main/java/com/project/singk/domain/member/infrastructure/MemberRepositoryImpl.java
+++ b/src/main/java/com/project/singk/domain/member/infrastructure/MemberRepositoryImpl.java
@@ -58,4 +58,9 @@ public class MemberRepositoryImpl implements MemberRepository {
 	public boolean existsByNickname(String nickname) {
 		return memberJpaRepository.existsByNickname(nickname);
 	}
+
+    @Override
+    public void deleteById(Long memberId) {
+        memberJpaRepository.deleteById(memberId);
+    }
 }

--- a/src/main/java/com/project/singk/domain/member/service/port/MemberRepository.java
+++ b/src/main/java/com/project/singk/domain/member/service/port/MemberRepository.java
@@ -8,10 +8,11 @@ import com.project.singk.domain.member.domain.Member;
 public interface MemberRepository {
 	Member save(Member member);
     List<Member> saveAll(List<Member> members);
-	Member getById(Long id);
+	Member getById(Long memberId);
 	Member getByEmail(String email);
-	Optional<Member> findById(Long id);
+	Optional<Member> findById(Long memberId);
 	Optional<Member> findByEmail(String email);
 	boolean existsByEmail(String email);
 	boolean existsByNickname(String nickname);
+    void deleteById(Long memberId);
 }

--- a/src/main/java/com/project/singk/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/singk/global/config/SecurityConfig.java
@@ -85,6 +85,7 @@ public class SecurityConfig {
 					.requestMatchers("/api/auth/**").permitAll()
 					.requestMatchers("/api/albums/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/reviews/**").permitAll()
+                    .requestMatchers("/api/admin/**").hasRole("ADMIN")
 					.anyRequest().authenticated();
 			})
 			// API 엔드포인트 예외 핸들러

--- a/src/main/java/com/project/singk/global/properties/AdminProperties.java
+++ b/src/main/java/com/project/singk/global/properties/AdminProperties.java
@@ -1,0 +1,18 @@
+package com.project.singk.global.properties;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
+
+@Getter @ToString
+@AllArgsConstructor
+@ConfigurationProperties(prefix = "admin")
+@ConfigurationPropertiesBinding
+public class AdminProperties {
+
+	private final String email;
+	private final String password;
+
+}

--- a/src/main/java/com/project/singk/global/scheduler/DataLoader.java
+++ b/src/main/java/com/project/singk/global/scheduler/DataLoader.java
@@ -1,0 +1,36 @@
+package com.project.singk.global.scheduler;
+
+import com.project.singk.domain.member.domain.Member;
+import com.project.singk.domain.member.domain.MemberStatistics;
+import com.project.singk.domain.member.domain.Role;
+import com.project.singk.domain.member.service.port.MemberRepository;
+import com.project.singk.domain.member.service.port.PasswordEncoderHolder;
+import com.project.singk.global.properties.AdminProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DataLoader implements ApplicationRunner {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoderHolder passwordEncoderHolder;
+    private final AdminProperties adminProperties;
+
+    @Override
+    public void run(ApplicationArguments args) {
+
+        if (memberRepository.existsByEmail(adminProperties.getEmail())) return;
+
+        // Admin 계정 생성
+        Member member = memberRepository.save(Member.builder()
+                .email(adminProperties.getEmail())
+                .password(passwordEncoderHolder.encode(adminProperties.getPassword()))
+                .nickname("관리자")
+                .role(Role.ROLE_ADMIN)
+                .statistics(MemberStatistics.empty())
+                .build());
+    }
+}

--- a/src/test/java/com/project/singk/domain/album/controller/response/AlbumDetailResponseTest.java
+++ b/src/test/java/com/project/singk/domain/album/controller/response/AlbumDetailResponseTest.java
@@ -29,10 +29,10 @@ class AlbumDetailResponseTest {
                         .name("Bubble Gum (Instrumental)")
                         .build()
         );
-        List<Artist> artists = List.of(
-                Artist.builder()
+        List<AlbumArtist> artists = List.of(
+                AlbumArtist.from(Artist.builder()
                         .name("NewJeans")
-                        .build()
+                        .build())
         );
         List<AlbumImage> images = List.of(
                 AlbumImage.builder()

--- a/src/test/java/com/project/singk/domain/album/controller/response/AlbumListResponseTest.java
+++ b/src/test/java/com/project/singk/domain/album/controller/response/AlbumListResponseTest.java
@@ -14,10 +14,10 @@ class AlbumListResponseTest {
     @Test
     public void AlbumListResponseTest를_만들_수_있다() {
         // given
-        List<Artist> artists = List.of(
-                Artist.builder()
+        List<AlbumArtist> artists = List.of(
+                AlbumArtist.from(Artist.builder()
                         .name("NewJeans")
-                        .build()
+                        .build())
         );
         List<AlbumImage> images = List.of(
                 AlbumImage.builder()

--- a/src/test/java/com/project/singk/domain/album/controller/response/AlbumSimpleResponseTest.java
+++ b/src/test/java/com/project/singk/domain/album/controller/response/AlbumSimpleResponseTest.java
@@ -1,9 +1,6 @@
 package com.project.singk.domain.album.controller.response;
 
-import com.project.singk.domain.album.domain.Album;
-import com.project.singk.domain.album.domain.AlbumImage;
-import com.project.singk.domain.album.domain.AlbumType;
-import com.project.singk.domain.album.domain.Artist;
+import com.project.singk.domain.album.domain.*;
 import com.project.singk.domain.review.domain.AlbumReviewStatistics;
 import org.junit.jupiter.api.Test;
 
@@ -17,10 +14,10 @@ class AlbumSimpleResponseTest {
     @Test
     public void Album으로_AlbumSimpleResponseTest를_만들_수_있다() {
         // given
-        List<Artist> artists = List.of(
-                Artist.builder()
+        List<AlbumArtist> artists = List.of(
+                AlbumArtist.from(Artist.builder()
                         .name("NewJeans")
-                        .build()
+                        .build())
         );
         List<AlbumImage> images = List.of(
                 AlbumImage.builder()

--- a/src/test/java/com/project/singk/domain/album/service/AlbumServiceTest.java
+++ b/src/test/java/com/project/singk/domain/album/service/AlbumServiceTest.java
@@ -63,10 +63,10 @@ class AlbumServiceTest {
                         .name("Bubble Gum (Instrumental)")
                         .build()
         );
-        List<Artist> artists = List.of(
-                Artist.builder()
+        List<AlbumArtist> artists = List.of(
+                AlbumArtist.from(Artist.builder()
                         .name("NewJeans")
-                        .build()
+                        .build())
         );
         List<AlbumImage> images = List.of(
                 AlbumImage.builder()

--- a/src/test/java/com/project/singk/mock/FakeAlbumRepository.java
+++ b/src/test/java/com/project/singk/mock/FakeAlbumRepository.java
@@ -30,6 +30,12 @@ public class FakeAlbumRepository implements AlbumRepository {
     }
 
     @Override
+    public boolean existsById(String albumId) {
+        return data.stream()
+                .anyMatch(item -> item.getId().equals(albumId));
+    }
+
+    @Override
     public Album getById(String id) {
         return findById(id).orElseThrow(() -> new ApiException(AppHttpStatus.NOT_FOUND_ALBUM));
     }

--- a/src/test/java/com/project/singk/mock/FakeArtistRepository.java
+++ b/src/test/java/com/project/singk/mock/FakeArtistRepository.java
@@ -20,4 +20,10 @@ public class FakeArtistRepository implements ArtistRepository {
         return artists.stream().map(this::save).toList();
     }
 
+    @Override
+    public boolean existById(String artistId) {
+        return data.stream()
+                .anyMatch(item -> item.getId().equals(artistId));
+    }
+
 }

--- a/src/test/java/com/project/singk/mock/FakeMemberRepository.java
+++ b/src/test/java/com/project/singk/mock/FakeMemberRepository.java
@@ -72,4 +72,9 @@ public class FakeMemberRepository implements MemberRepository {
 	public boolean existsByNickname(String nickname) {
 		return data.stream().anyMatch(item -> item.getNickname().equals(nickname));
 	}
+
+    @Override
+    public void deleteById(Long memberId) {
+        data.removeIf(item -> item.getId().equals(memberId));
+    }
 }


### PR DESCRIPTION
## 구현 내용
- 앨범 아티스트 PK 중복으로 인한 테이블 분리
- 서버 실행 시 어드민 계정 생성
- 어드민 전용 API 구현
