### PR TITLE
히스토리 그래프 기능 구현

### DIFF
--- a/src/main/java/com/project/singk/domain/activity/controller/ActivityHistoryController.java
+++ b/src/main/java/com/project/singk/domain/activity/controller/ActivityHistoryController.java
@@ -1,12 +1,14 @@
 package com.project.singk.domain.activity.controller;
 
 import com.project.singk.domain.activity.controller.port.ActivityHistoryService;
+import com.project.singk.domain.activity.controller.request.ActivityDate;
 import com.project.singk.domain.activity.controller.response.ActivityGraphResponse;
 import com.project.singk.domain.activity.controller.response.ActivityHistoryResponse;
 import com.project.singk.domain.member.controller.port.AuthService;
 import com.project.singk.global.api.BaseResponse;
 import com.project.singk.global.api.PageResponse;
 import com.project.singk.global.validate.Date;
+import com.project.singk.global.validate.ValidEnum;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Range;
 import org.springframework.validation.annotation.Validated;
@@ -15,8 +17,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Validated
@@ -28,9 +28,16 @@ public class ActivityHistoryController {
     private final AuthService authService;
 
     @GetMapping("/graph")
-    public BaseResponse<List<ActivityGraphResponse>> getActivityHistoryGraph() {
+    public BaseResponse<List<ActivityGraphResponse>> getActivityHistoryGraph(
+            @Date @RequestParam("startDate") String startDate,
+            @Date @RequestParam("endDate") String endDate,
+            @ValidEnum(enumClass = ActivityDate.class, ignoreCase = false) @RequestParam("type") String type
+    ) {
         return BaseResponse.ok(activityHistoryService.getActivityGraph(
-                authService.getLoginMemberId()
+                authService.getLoginMemberId(),
+                startDate,
+                endDate,
+                type
         ));
     }
 
@@ -52,6 +59,29 @@ public class ActivityHistoryController {
             @Date @RequestParam("endDate") String endDate
     ) {
         return BaseResponse.ok(activityHistoryService.getDailyActivityGraph(
+                authService.getLoginMemberId(),
+                startDate,
+                endDate
+        ));
+    }
+    @GetMapping("/weekly/graph")
+    public BaseResponse<List<ActivityGraphResponse>> getWeeklyActivityGraph(
+            @Date @RequestParam("startDate") String startDate,
+            @Date @RequestParam("endDate") String endDate
+    ) {
+        return BaseResponse.ok(activityHistoryService.getWeeklyActivityGraph(
+                authService.getLoginMemberId(),
+                startDate,
+                endDate
+        ));
+    }
+
+    @GetMapping("/monthly/graph")
+    public BaseResponse<List<ActivityGraphResponse>> getMonthlyActivityGraph(
+            @Date @RequestParam("startDate") String startDate,
+            @Date @RequestParam("endDate") String endDate
+    ) {
+        return BaseResponse.ok(activityHistoryService.getMonthlyActivityGraph(
                 authService.getLoginMemberId(),
                 startDate,
                 endDate

--- a/src/main/java/com/project/singk/domain/activity/controller/ActivityHistoryController.java
+++ b/src/main/java/com/project/singk/domain/activity/controller/ActivityHistoryController.java
@@ -6,6 +6,7 @@ import com.project.singk.domain.activity.controller.response.ActivityHistoryResp
 import com.project.singk.domain.member.controller.port.AuthService;
 import com.project.singk.global.api.BaseResponse;
 import com.project.singk.global.api.PageResponse;
+import com.project.singk.global.validate.Date;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Range;
 import org.springframework.validation.annotation.Validated;
@@ -14,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Validated
@@ -40,6 +43,18 @@ public class ActivityHistoryController {
                 authService.getLoginMemberId(),
                 offset,
                 limit
+        ));
+    }
+
+    @GetMapping("/daily/graph")
+    public BaseResponse<List<ActivityGraphResponse>> getDailyActivityGraph(
+            @Date @RequestParam("startDate") String startDate,
+            @Date @RequestParam("endDate") String endDate
+    ) {
+        return BaseResponse.ok(activityHistoryService.getDailyActivityGraph(
+                authService.getLoginMemberId(),
+                startDate,
+                endDate
         ));
     }
 }

--- a/src/main/java/com/project/singk/domain/activity/controller/port/ActivityHistoryService.java
+++ b/src/main/java/com/project/singk/domain/activity/controller/port/ActivityHistoryService.java
@@ -9,4 +9,5 @@ import java.util.List;
 public interface ActivityHistoryService {
     List<ActivityGraphResponse> getActivityGraph(Long memberId);
     PageResponse<ActivityHistoryResponse> getActivityHistories(Long memberId, int offset, int limit);
+    List<ActivityGraphResponse> getDailyActivityGraph(Long memberId, String startDate, String endDate);
 }

--- a/src/main/java/com/project/singk/domain/activity/controller/port/ActivityHistoryService.java
+++ b/src/main/java/com/project/singk/domain/activity/controller/port/ActivityHistoryService.java
@@ -7,7 +7,10 @@ import com.project.singk.global.api.PageResponse;
 import java.util.List;
 
 public interface ActivityHistoryService {
-    List<ActivityGraphResponse> getActivityGraph(Long memberId);
+    List<ActivityGraphResponse> getActivityGraph(Long memberId, String startDate, String endDate, String dateType);
     PageResponse<ActivityHistoryResponse> getActivityHistories(Long memberId, int offset, int limit);
     List<ActivityGraphResponse> getDailyActivityGraph(Long memberId, String startDate, String endDate);
+    List<ActivityGraphResponse> getWeeklyActivityGraph(Long memberId, String startDate, String endDate);
+
+    List<ActivityGraphResponse> getMonthlyActivityGraph(Long memberId, String startDate, String endDate);
 }

--- a/src/main/java/com/project/singk/domain/activity/controller/request/ActivityDate.java
+++ b/src/main/java/com/project/singk/domain/activity/controller/request/ActivityDate.java
@@ -1,0 +1,12 @@
+package com.project.singk.domain.activity.controller.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ActivityDate {
+    DAILY,
+    WEEKLY,
+    MONTHLY
+}

--- a/src/main/java/com/project/singk/domain/activity/controller/response/ActivityGraphResponse.java
+++ b/src/main/java/com/project/singk/domain/activity/controller/response/ActivityGraphResponse.java
@@ -1,24 +1,31 @@
 package com.project.singk.domain.activity.controller.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.project.singk.domain.activity.domain.ActivityScore;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 @Builder
 @ToString
 public class ActivityGraphResponse {
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
-    private LocalDateTime date;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM.dd", timezone = "Asia/Seoul")
+    private LocalDate date;
     private int score;
 
-    public static ActivityGraphResponse from (LocalDateTime date, int score) {
+    public static ActivityGraphResponse from (LocalDate date, int score) {
         return ActivityGraphResponse.builder()
                 .date(date)
                 .score(score)
+                .build();
+    }
+    public static ActivityGraphResponse from (ActivityScore activityScore) {
+        return ActivityGraphResponse.builder()
+                .date(activityScore.getDate())
+                .score(activityScore.getScore())
                 .build();
     }
 }

--- a/src/main/java/com/project/singk/domain/activity/domain/ActivityHistory.java
+++ b/src/main/java/com/project/singk/domain/activity/domain/ActivityHistory.java
@@ -30,4 +30,13 @@ public class ActivityHistory {
                 .member(member)
                 .build();
     }
+
+    public ActivityHistory setAccumulatedScore(int score) {
+        return ActivityHistory.builder()
+                .type(this.type)
+                .score(score)
+                .member(this.member)
+                .createdAt(this.createdAt)
+                .build();
+    }
 }

--- a/src/main/java/com/project/singk/domain/activity/domain/ActivityScore.java
+++ b/src/main/java/com/project/singk/domain/activity/domain/ActivityScore.java
@@ -1,0 +1,25 @@
+package com.project.singk.domain.activity.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class ActivityScore {
+    private final int score;
+    private final LocalDate date;
+
+    @Builder
+    public ActivityScore(int score, LocalDate date) {
+        this.score = score;
+        this.date = date;
+    }
+
+    public static ActivityScore from(int score, LocalDate date) {
+        return ActivityScore.builder()
+                .score(score)
+                .date(date)
+                .build();
+    }
+}

--- a/src/main/java/com/project/singk/domain/activity/infrastructure/ActivityHistoryEntity.java
+++ b/src/main/java/com/project/singk/domain/activity/infrastructure/ActivityHistoryEntity.java
@@ -9,6 +9,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "ACTIVITY_HISTORYS", indexes = {
         @Index(name = "idx_activity_historys_created_at", columnList = "createdAt DESC"),
@@ -33,11 +35,13 @@ public class ActivityHistoryEntity extends BaseTimeEntity {
     private MemberEntity member;
 
     @Builder
-    public ActivityHistoryEntity(Long id, ActivityType type, int score, MemberEntity member) {
+    public ActivityHistoryEntity(Long id, ActivityType type, int score, MemberEntity member, LocalDateTime createdAt) {
+        super(createdAt, null);
         this.id = id;
         this.type = type;
         this.score = score;
         this.member = member;
+        this.createdAt = createdAt;
     }
 
     public static ActivityHistoryEntity from (ActivityHistory activity) {
@@ -46,6 +50,7 @@ public class ActivityHistoryEntity extends BaseTimeEntity {
                 .type(activity.getType())
                 .score(activity.getScore())
                 .member(MemberEntity.from(activity.getMember()))
+                .createdAt(activity.getCreatedAt())
                 .build();
     }
 
@@ -55,7 +60,7 @@ public class ActivityHistoryEntity extends BaseTimeEntity {
                 .type(this.type)
                 .score(this.score)
                 .member(this.member.toModel())
-                .createdAt(this.getCreatedAt())
+                .createdAt(this.createdAt)
                 .build();
     }
 }

--- a/src/main/java/com/project/singk/domain/activity/infrastructure/ActivityHistoryRepositoryImpl.java
+++ b/src/main/java/com/project/singk/domain/activity/infrastructure/ActivityHistoryRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.project.singk.domain.activity.infrastructure;
 
+import com.project.singk.domain.activity.controller.request.ActivityDate;
 import com.project.singk.domain.activity.domain.ActivityHistory;
 import com.project.singk.domain.activity.domain.ActivityScore;
 import com.project.singk.domain.activity.service.port.ActivityHistoryRepository;
@@ -12,15 +13,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static com.project.singk.domain.activity.infrastructure.QActivityHistoryEntity.activityHistoryEntity;
-import static com.project.singk.domain.album.infrastructure.entity.QAlbumEntity.albumEntity;
-import static com.project.singk.domain.member.infrastructure.QMemberEntity.memberEntity;
-import static com.project.singk.domain.review.infrastructure.QAlbumReviewEntity.albumReviewEntity;
-import static java.util.stream.Collectors.groupingBy;
+
 
 @Repository
 @RequiredArgsConstructor
@@ -34,13 +33,23 @@ public class ActivityHistoryRepositoryImpl implements ActivityHistoryRepository 
     }
 
     @Override
-    public List<ActivityHistory> getActivityGraph(Long memberId) {
-        return queryFactory.selectFrom(activityHistoryEntity)
-                .where(activityHistoryEntity.member.id.eq(memberId))
-                .orderBy(activityHistoryEntity.createdAt.asc())
-                .fetch().stream()
+    public List<ActivityHistory> saveAll(List<ActivityHistory> activityHistories) {
+        return activityHistoryJpaRepository.saveAll(activityHistories.stream()
+                .map(ActivityHistoryEntity::from)
+                .toList()).stream()
                 .map(ActivityHistoryEntity::toModel)
-                .collect(Collectors.toList());
+                .toList();
+    }
+
+    @Override
+    public List<ActivityScore> getActivityGraph(Long memberId, LocalDate start, LocalDate end, ActivityDate type) {
+        // 누적합 구하기
+        List<ActivityHistory> accumulatedHistories = getAccumulatedHistories(memberId);
+
+        // 날짜 구하기
+        List<LocalDate> dates = getDates(start, end, type);
+
+        return getActivityScores(accumulatedHistories, dates);
     }
 
     @Override
@@ -65,6 +74,46 @@ public class ActivityHistoryRepositoryImpl implements ActivityHistoryRepository 
 
     @Override
     public List<ActivityScore> getActivityDailyGraph(Long memberId, LocalDate start, LocalDate end) {
+        // 누적합 구하기
+        List<ActivityHistory> accumulatedHistories = getAccumulatedHistories(memberId);
+
+        // 각 날짜별 최종 값 구하기
+        List<LocalDate> dates = start.datesUntil(end.plusDays(1)).toList(); // 호출 날짜 포함 7일
+
+        return getActivityScores(accumulatedHistories, dates);
+    }
+
+    @Override
+    public List<ActivityScore> getActivityWeeklyGraph(Long memberId, LocalDate start, LocalDate end) {
+        // 누적합 구하기
+        List<ActivityHistory> accumulatedHistories = getAccumulatedHistories(memberId);
+
+        // 각 주별 최종 값 구하기 - 각 주의 일요일
+        List<LocalDate> dates = new ArrayList<>(start.datesUntil(end.plusDays(1))
+                .filter(date -> date.getDayOfWeek() == DayOfWeek.SUNDAY)
+                .toList());
+
+        if (end.getDayOfWeek() != DayOfWeek.SUNDAY) dates.add(end);
+
+        return getActivityScores(accumulatedHistories, dates);
+    }
+
+    @Override
+    public List<ActivityScore> getActivityMonthlyGraph(Long memberId, LocalDate start, LocalDate end) {
+        // 누적합 구하기
+        List<ActivityHistory> accumulatedHistories = getAccumulatedHistories(memberId);
+
+        // 각 달별 최종 값 구하기 - 각 달의 마지막 날
+        List<LocalDate> dates = new ArrayList<>(start.datesUntil(end.plusDays(1))
+                .filter(date -> date.equals(YearMonth.from(date).atEndOfMonth()))
+                .toList());
+
+        if (!end.equals(YearMonth.from(end).atEndOfMonth())) dates.add(end);
+
+        return getActivityScores(accumulatedHistories, dates);
+    }
+
+    private List<ActivityHistory> getAccumulatedHistories(Long memberId) {
         List<ActivityHistory> activityHistories = queryFactory.select(activityHistoryEntity)
                 .from(activityHistoryEntity)
                 .where(activityHistoryEntity.member.id.eq(memberId))
@@ -81,11 +130,12 @@ public class ActivityHistoryRepositoryImpl implements ActivityHistoryRepository 
             accumulatedHistories.add(activityHistory.setAccumulatedScore(accumulateScore));
         }
 
-        // 각 날짜별 최종 값 구하기
-        List<ActivityScore> result = new ArrayList<>();
-        List<LocalDate> dates = start.datesUntil(end.plusDays(1)).toList(); // 호출 날짜 포함 7일
+        return accumulatedHistories;
+    }
 
+    private List<ActivityScore> getActivityScores(List<ActivityHistory> accumulatedHistories, List<LocalDate> dates) {
         int prev = 0;
+        List<ActivityScore> result = new ArrayList<>();
         for (LocalDate date : dates) {
             List<ActivityHistory> histories = accumulatedHistories.stream()
                     .filter(score -> score.getCreatedAt().isAfter(date.atStartOfDay()) && score.getCreatedAt().isBefore(date.plusDays(1).atStartOfDay()))
@@ -98,5 +148,31 @@ public class ActivityHistoryRepositoryImpl implements ActivityHistoryRepository 
         }
 
         return result;
+    }
+
+    private List<LocalDate> getDates(LocalDate start, LocalDate end, ActivityDate type) {
+        if (type.equals(ActivityDate.DAILY)) {
+            return start.datesUntil(end.plusDays(1)).toList();
+        } else if (type.equals(ActivityDate.WEEKLY)) {
+            // 각 주의 일요일
+            List<LocalDate> dates = new ArrayList<>(start.datesUntil(end.plusDays(1))
+                    .filter(date -> date.getDayOfWeek() == DayOfWeek.SUNDAY)
+                    .toList());
+
+            if (end.getDayOfWeek() != DayOfWeek.SUNDAY) dates.add(end);
+
+            return dates;
+        } else if (type.equals(ActivityDate.MONTHLY)) {
+            // 각 달의 마지막 날
+            List<LocalDate> dates = new ArrayList<>(start.datesUntil(end.plusDays(1))
+                    .filter(date -> date.equals(YearMonth.from(date).atEndOfMonth()))
+                    .toList());
+
+            if (!end.equals(YearMonth.from(end).atEndOfMonth())) dates.add(end);
+
+            return dates;
+        }
+
+        return null;
     }
 }

--- a/src/main/java/com/project/singk/domain/activity/infrastructure/ActivityHistoryRepositoryImpl.java
+++ b/src/main/java/com/project/singk/domain/activity/infrastructure/ActivityHistoryRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.project.singk.domain.activity.infrastructure;
 
 import com.project.singk.domain.activity.domain.ActivityHistory;
+import com.project.singk.domain.activity.domain.ActivityScore;
 import com.project.singk.domain.activity.service.port.ActivityHistoryRepository;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -11,13 +12,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import java.time.LocalDate;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.project.singk.domain.activity.infrastructure.QActivityHistoryEntity.activityHistoryEntity;
 import static com.project.singk.domain.album.infrastructure.entity.QAlbumEntity.albumEntity;
 import static com.project.singk.domain.member.infrastructure.QMemberEntity.memberEntity;
 import static com.project.singk.domain.review.infrastructure.QAlbumReviewEntity.albumReviewEntity;
+import static java.util.stream.Collectors.groupingBy;
 
 @Repository
 @RequiredArgsConstructor
@@ -60,4 +63,40 @@ public class ActivityHistoryRepositoryImpl implements ActivityHistoryRepository 
         return PageableExecutionUtils.getPage(activityHistories, pageable, count::fetchOne);
     }
 
+    @Override
+    public List<ActivityScore> getActivityDailyGraph(Long memberId, LocalDate start, LocalDate end) {
+        List<ActivityHistory> activityHistories = queryFactory.select(activityHistoryEntity)
+                .from(activityHistoryEntity)
+                .where(activityHistoryEntity.member.id.eq(memberId))
+                .orderBy(activityHistoryEntity.createdAt.asc())
+                .fetch().stream()
+                .map(ActivityHistoryEntity::toModel)
+                .toList();
+
+        // 누적합 구하기
+        int accumulateScore = 0;
+        List<ActivityHistory> accumulatedHistories = new ArrayList<>();
+        for (ActivityHistory activityHistory : activityHistories) {
+            accumulateScore += activityHistory.getScore();
+            accumulatedHistories.add(activityHistory.setAccumulatedScore(accumulateScore));
+        }
+
+        // 각 날짜별 최종 값 구하기
+        List<ActivityScore> result = new ArrayList<>();
+        List<LocalDate> dates = start.datesUntil(end.plusDays(1)).toList(); // 호출 날짜 포함 7일
+
+        int prev = 0;
+        for (LocalDate date : dates) {
+            List<ActivityHistory> histories = accumulatedHistories.stream()
+                    .filter(score -> score.getCreatedAt().isAfter(date.atStartOfDay()) && score.getCreatedAt().isBefore(date.plusDays(1).atStartOfDay()))
+                    .sorted(Comparator.comparing(ActivityHistory::getCreatedAt).reversed())
+                    .toList();
+
+            if (!histories.isEmpty()) prev = histories.get(0).getScore();
+
+            result.add(ActivityScore.from(prev, date));
+        }
+
+        return result;
+    }
 }

--- a/src/main/java/com/project/singk/domain/activity/service/ActivityHistoryServiceImpl.java
+++ b/src/main/java/com/project/singk/domain/activity/service/ActivityHistoryServiceImpl.java
@@ -1,6 +1,7 @@
 package com.project.singk.domain.activity.service;
 
 import com.project.singk.domain.activity.controller.port.ActivityHistoryService;
+import com.project.singk.domain.activity.controller.request.ActivityDate;
 import com.project.singk.domain.activity.controller.response.ActivityGraphResponse;
 import com.project.singk.domain.activity.controller.response.ActivityHistoryResponse;
 import com.project.singk.domain.activity.domain.ActivityHistory;
@@ -15,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 @Service
@@ -26,17 +26,18 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
 
     private final ActivityHistoryRepository activityHistoryRepository;
     @Override
-    public List<ActivityGraphResponse> getActivityGraph(Long memberId) {
-        AtomicInteger accumulatedScore = new AtomicInteger(0);
-        return activityHistoryRepository.getActivityGraph(memberId).stream()
-                .map(activity -> {
-                    accumulatedScore.addAndGet(activity.getScore());
+    public List<ActivityGraphResponse> getActivityGraph(Long memberId, String startDate, String endDate, String dateType) {
+        LocalDate start = LocalDate.parse(startDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        LocalDate end = LocalDate.parse(endDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        ActivityDate type = ActivityDate.valueOf(dateType);
 
-                    return ActivityGraphResponse.builder()
-                            .date(activity.getCreatedAt().toLocalDate())
-                            .score(accumulatedScore.get())
-                            .build();
-                })
+        return activityHistoryRepository.getActivityGraph(
+                        memberId,
+                        start,
+                        end,
+                        type
+                ).stream()
+                .map(ActivityGraphResponse::from)
                 .collect(Collectors.toList());
     }
 
@@ -66,6 +67,34 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
             ).stream()
             .map(ActivityGraphResponse::from)
             .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<ActivityGraphResponse> getWeeklyActivityGraph(Long memberId, String startDate, String endDate) {
+        LocalDate start = LocalDate.parse(startDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        LocalDate end = LocalDate.parse(endDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+        return activityHistoryRepository.getActivityWeeklyGraph(
+                        memberId,
+                        start,
+                        end
+                ).stream()
+                .map(ActivityGraphResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<ActivityGraphResponse> getMonthlyActivityGraph(Long memberId, String startDate, String endDate) {
+        LocalDate start = LocalDate.parse(startDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        LocalDate end = LocalDate.parse(endDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+        return activityHistoryRepository.getActivityMonthlyGraph(
+                        memberId,
+                        start,
+                        end
+                ).stream()
+                .map(ActivityGraphResponse::from)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/project/singk/domain/activity/service/ActivityHistoryServiceImpl.java
+++ b/src/main/java/com/project/singk/domain/activity/service/ActivityHistoryServiceImpl.java
@@ -12,6 +12,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -31,7 +33,7 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
                     accumulatedScore.addAndGet(activity.getScore());
 
                     return ActivityGraphResponse.builder()
-                            .date(activity.getCreatedAt())
+                            .date(activity.getCreatedAt().toLocalDate())
                             .score(accumulatedScore.get())
                             .build();
                 })
@@ -51,4 +53,19 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
                         .toList()
         );
     }
+
+    @Override
+    public List<ActivityGraphResponse> getDailyActivityGraph(Long memberId, String startDate, String endDate) {
+        LocalDate start = LocalDate.parse(startDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        LocalDate end = LocalDate.parse(endDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+        return activityHistoryRepository.getActivityDailyGraph(
+                memberId,
+                start,
+                end
+            ).stream()
+            .map(ActivityGraphResponse::from)
+            .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/com/project/singk/domain/activity/service/port/ActivityHistoryRepository.java
+++ b/src/main/java/com/project/singk/domain/activity/service/port/ActivityHistoryRepository.java
@@ -1,5 +1,6 @@
 package com.project.singk.domain.activity.service.port;
 
+import com.project.singk.domain.activity.controller.request.ActivityDate;
 import com.project.singk.domain.activity.domain.ActivityHistory;
 import com.project.singk.domain.activity.domain.ActivityScore;
 import org.springframework.data.domain.Page;
@@ -9,8 +10,12 @@ import java.util.List;
 
 public interface ActivityHistoryRepository {
     ActivityHistory save(ActivityHistory activityHistory);
-    List<ActivityHistory> getActivityGraph(Long memberId);
+    List<ActivityHistory> saveAll(List<ActivityHistory> activityHistories);
+    List<ActivityScore> getActivityGraph(Long memberId, LocalDate start, LocalDate end, ActivityDate type);
     Page<ActivityHistory> getActivityHistories(Long memberId, int offset, int limit);
 
     List<ActivityScore> getActivityDailyGraph(Long memberId, LocalDate start, LocalDate end);
+    List<ActivityScore> getActivityWeeklyGraph(Long memberId, LocalDate start, LocalDate end);
+
+    List<ActivityScore> getActivityMonthlyGraph(Long memberId, LocalDate start, LocalDate end);
 }

--- a/src/main/java/com/project/singk/domain/activity/service/port/ActivityHistoryRepository.java
+++ b/src/main/java/com/project/singk/domain/activity/service/port/ActivityHistoryRepository.java
@@ -1,12 +1,16 @@
 package com.project.singk.domain.activity.service.port;
 
 import com.project.singk.domain.activity.domain.ActivityHistory;
+import com.project.singk.domain.activity.domain.ActivityScore;
 import org.springframework.data.domain.Page;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface ActivityHistoryRepository {
     ActivityHistory save(ActivityHistory activityHistory);
     List<ActivityHistory> getActivityGraph(Long memberId);
     Page<ActivityHistory> getActivityHistories(Long memberId, int offset, int limit);
+
+    List<ActivityScore> getActivityDailyGraph(Long memberId, LocalDate start, LocalDate end);
 }

--- a/src/main/java/com/project/singk/domain/admin/controller/CreateAdminController.java
+++ b/src/main/java/com/project/singk/domain/admin/controller/CreateAdminController.java
@@ -1,14 +1,18 @@
 package com.project.singk.domain.admin.controller;
 
+import com.project.singk.domain.activity.controller.response.ActivityHistoryResponse;
 import com.project.singk.domain.admin.controller.port.AdminService;
 import com.project.singk.domain.album.controller.response.AlbumDetailResponse;
 import com.project.singk.domain.member.controller.port.AuthService;
 import com.project.singk.global.api.BaseResponse;
 import com.project.singk.global.api.PageResponse;
+import com.project.singk.global.validate.Date;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Range;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Validated
 @RestController
@@ -26,4 +30,18 @@ public class CreateAdminController {
 	) {
 		return BaseResponse.ok(adminService.createAlbums(query, offset, limit));
 	}
+
+    @PostMapping("/activity-histories")
+    public BaseResponse<List<ActivityHistoryResponse>> createActivityHistories(
+            @Date @RequestParam("startDate") String startDate,
+            @Date @RequestParam("endDate") String endDate,
+            @RequestParam("count") int count
+    ) {
+        return BaseResponse.ok(adminService.createActivityHistories(
+                authService.getLoginMemberId(),
+                startDate,
+                endDate,
+                count
+        ));
+    }
 }

--- a/src/main/java/com/project/singk/domain/admin/controller/port/AdminService.java
+++ b/src/main/java/com/project/singk/domain/admin/controller/port/AdminService.java
@@ -1,5 +1,6 @@
 package com.project.singk.domain.admin.controller.port;
 
+import com.project.singk.domain.activity.controller.response.ActivityHistoryResponse;
 import com.project.singk.domain.album.controller.response.AlbumDetailResponse;
 import com.project.singk.domain.member.controller.response.MemberResponse;
 import com.project.singk.global.api.PageResponse;
@@ -10,4 +11,5 @@ public interface AdminService {
     PageResponse<AlbumDetailResponse> createAlbums(String query, int offset, int limit);
     void deleteMember(Long memberId);
     List<MemberResponse> getMembers();
+    List<ActivityHistoryResponse> createActivityHistories(Long memberId, String startDate, String endDate, int count);
 }

--- a/src/main/java/com/project/singk/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/project/singk/domain/admin/service/AdminServiceImpl.java
@@ -1,12 +1,19 @@
 package com.project.singk.domain.admin.service;
 
+import com.project.singk.domain.activity.controller.response.ActivityHistoryResponse;
+import com.project.singk.domain.activity.domain.ActivityHistory;
+import com.project.singk.domain.activity.domain.ActivityType;
+import com.project.singk.domain.activity.infrastructure.ActivityHistoryEntity;
+import com.project.singk.domain.activity.service.port.ActivityHistoryRepository;
 import com.project.singk.domain.admin.controller.port.AdminService;
 import com.project.singk.domain.album.controller.response.AlbumDetailResponse;
 import com.project.singk.domain.album.domain.*;
 import com.project.singk.domain.album.infrastructure.spotify.AlbumSimplifiedEntity;
 import com.project.singk.domain.album.service.port.*;
+import com.project.singk.domain.common.service.port.RandomHolder;
 import com.project.singk.domain.common.service.port.S3Repository;
 import com.project.singk.domain.member.controller.response.MemberResponse;
+import com.project.singk.domain.member.domain.Member;
 import com.project.singk.domain.member.service.port.MemberRepository;
 import com.project.singk.domain.review.domain.AlbumReviewStatistics;
 import com.project.singk.global.api.PageResponse;
@@ -15,9 +22,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @Builder
@@ -30,7 +42,8 @@ public class AdminServiceImpl implements AdminService {
     private final ArtistRepository artistRepository;
     private final MemberRepository memberRepository;
     private final S3Repository s3Repository;
-
+    private final RandomHolder randomHolder;
+    private final ActivityHistoryRepository activityHistoryRepository;
     @Override
     public PageResponse<AlbumDetailResponse> createAlbums(String query, int offset, int limit) {
 
@@ -91,6 +104,40 @@ public class AdminServiceImpl implements AdminService {
                     String imageUrl = s3Repository.getPreSignedGetUrl(member.getImageUrl());
                     return MemberResponse.from(member, imageUrl);
                 })
+                .toList();
+    }
+
+    @Override
+    public List<ActivityHistoryResponse> createActivityHistories(Long memberId, String startDate, String endDate, int count) {
+        LocalDate start = LocalDate.parse(startDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        LocalDate end = LocalDate.parse(endDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        Member member = memberRepository.getById(memberId);
+
+        List<LocalDateTime> dateTimes = start.datesUntil(end.plusDays(1))
+                .map(date -> date.atStartOfDay().plusHours(randomHolder.randomInt(12) + 1))
+                .toList();
+        ActivityType[] activityTypes = ActivityType.values();
+
+        List<ActivityHistory> activityHistories = new ArrayList<>();
+        for (LocalDateTime dateTime : dateTimes) {
+            for (int i = 0; i < count; i++) {
+                ActivityType type = activityTypes[randomHolder.randomInt(activityTypes.length)];
+                activityHistories.add(
+                        ActivityHistory.builder()
+                                .type(type)
+                                .score(type.getScore())
+                                .member(member)
+                                .createdAt(dateTime)
+                                .build()
+                );
+            }
+        }
+
+        ActivityHistoryEntity entity = ActivityHistoryEntity.from(activityHistories.get(0));
+        System.out.println(entity.getCreatedAt());
+
+        return activityHistoryRepository.saveAll(activityHistories).stream()
+                .map(ActivityHistoryResponse::from)
                 .toList();
     }
 }

--- a/src/main/java/com/project/singk/global/domain/BaseTimeEntity.java
+++ b/src/main/java/com/project/singk/global/domain/BaseTimeEntity.java
@@ -4,6 +4,9 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
 import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -13,23 +16,30 @@ import lombok.Getter;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
+@SuperBuilder // 상속한 필드를 빌더에 포함
+@NoArgsConstructor
 public abstract class BaseTimeEntity {
 
 	@Column(updatable = false)
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
-	private LocalDateTime createdAt;
+	protected LocalDateTime createdAt;
 
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
-	private LocalDateTime modifiedAt;
+	protected LocalDateTime modifiedAt;
 
     @PrePersist
     public void prePersist() {
-        this.createdAt = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
-        this.modifiedAt = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
+        this.createdAt = this.createdAt == null ? LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS) : this.createdAt;
+        this.modifiedAt = this.modifiedAt == null ? LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS) : this.modifiedAt;
     }
 
     @PreUpdate
     public void preUpdate() {
         this.modifiedAt = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
+    }
+
+    public BaseTimeEntity(LocalDateTime createdAt, LocalDateTime modifiedAt) {
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
     }
 }

--- a/src/test/java/SimpleTest.java
+++ b/src/test/java/SimpleTest.java
@@ -3,6 +3,7 @@ import lombok.Getter;
 import lombok.ToString;
 import org.junit.jupiter.api.Test;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -65,6 +66,17 @@ public class SimpleTest {
         System.out.println("Result Activity History ----");
         for (History history : resultHistory) {
             System.out.println(history);
+        }
+
+        System.out.println("Weekly Sunday LocalDate ----");
+        List<LocalDate> weeks = new ArrayList<>(LocalDate.now().minusMonths(2).datesUntil(LocalDate.now().plusDays(1))
+                .filter(date -> date.getDayOfWeek() == DayOfWeek.SUNDAY)
+                .toList());
+
+        if (LocalDate.now().getDayOfWeek() != DayOfWeek.SUNDAY) weeks.add(LocalDate.now());
+
+        for (LocalDate week : weeks) {
+            System.out.println(week);
         }
     }
 

--- a/src/test/java/SimpleTest.java
+++ b/src/test/java/SimpleTest.java
@@ -1,0 +1,83 @@
+
+import lombok.Getter;
+import lombok.ToString;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+
+public class SimpleTest {
+
+    @Test
+    void LocalDate를_테스트한다() {
+        // given
+        Random random = new Random(18);
+        int bound = 10;
+        List<History> histories = List.of(
+                new History(LocalDateTime.now().minusDays(5), random.nextInt(bound) + 1),
+                new History(LocalDateTime.now().minusDays(5), random.nextInt(bound) + 1),
+                new History(LocalDateTime.now().minusDays(4), random.nextInt(bound) + 1),
+                new History(LocalDateTime.now().minusDays(4), random.nextInt(bound) + 1),
+                new History(LocalDateTime.now().minusDays(3), random.nextInt(bound) + 1),
+                new History(LocalDateTime.now().minusDays(2), random.nextInt(bound) + 1),
+                new History(LocalDateTime.now(), random.nextInt(bound))
+        );
+        System.out.println("Initial Activity History ----");
+        for (History history : histories) {
+            System.out.println(history);
+        }
+
+        // when
+        List<History> accumulateHistories = new ArrayList<>();
+        int accumulateScore = 0;
+        for (History history : histories) {
+            accumulateScore += history.getScore();
+            accumulateHistories.add(new History(history.getCreatedAt(), accumulateScore));
+        }
+
+        System.out.println("Accumulate Activity History ----");
+        for (History history : accumulateHistories) {
+            System.out.println(history);
+        }
+
+        // then
+
+        List<History> resultHistory = new ArrayList<>();
+        List<LocalDate> dates = LocalDate.now().minusDays(6).datesUntil(LocalDate.now().plusDays(1)).toList();
+        int prev = 0;
+        for(LocalDate date : dates) {
+            List<History> h = accumulateHistories.stream()
+                    .filter(score -> score.getCreatedAt().isAfter(date.atStartOfDay()) && score.getCreatedAt().isBefore(date.plusDays(1).atStartOfDay()))
+                    .sorted(Comparator.comparing(History::getCreatedAt).reversed())
+                    .toList();
+
+            if (h.isEmpty()) resultHistory.add(new History(date.atStartOfDay(), prev));
+            else {
+                prev = h.get(0).getScore();
+                resultHistory.add(new History(date.atStartOfDay(), prev));
+            }
+        }
+
+        System.out.println("Result Activity History ----");
+        for (History history : resultHistory) {
+            System.out.println(history);
+        }
+    }
+
+    @Getter
+    @ToString
+    public static class History {
+        private LocalDateTime createdAt;
+        private int score;
+
+        public History(LocalDateTime createdAt, int score) {
+            this.createdAt = createdAt;
+            this.score = score;
+        }
+    }
+
+}

--- a/src/test/java/com/project/singk/mock/FakeActivityHistoryRepository.java
+++ b/src/test/java/com/project/singk/mock/FakeActivityHistoryRepository.java
@@ -1,9 +1,11 @@
 package com.project.singk.mock;
 
 import com.project.singk.domain.activity.domain.ActivityHistory;
+import com.project.singk.domain.activity.domain.ActivityScore;
 import com.project.singk.domain.activity.service.port.ActivityHistoryRepository;
 import org.springframework.data.domain.Page;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -26,6 +28,11 @@ public class FakeActivityHistoryRepository implements ActivityHistoryRepository 
 
     @Override
     public Page<ActivityHistory> getActivityHistories(Long memberId, int offset, int limit) {
+        return null;
+    }
+
+    @Override
+    public List<ActivityScore> getActivityDailyGraph(Long memberId, LocalDate start, LocalDate end) {
         return null;
     }
 

--- a/src/test/java/com/project/singk/mock/FakeActivityHistoryRepository.java
+++ b/src/test/java/com/project/singk/mock/FakeActivityHistoryRepository.java
@@ -1,5 +1,6 @@
 package com.project.singk.mock;
 
+import com.project.singk.domain.activity.controller.request.ActivityDate;
 import com.project.singk.domain.activity.domain.ActivityHistory;
 import com.project.singk.domain.activity.domain.ActivityScore;
 import com.project.singk.domain.activity.service.port.ActivityHistoryRepository;
@@ -22,7 +23,7 @@ public class FakeActivityHistoryRepository implements ActivityHistoryRepository 
     }
 
     @Override
-    public List<ActivityHistory> getActivityGraph(Long memberId) {
+    public List<ActivityScore> getActivityGraph(Long memberId, LocalDate start, LocalDate end, ActivityDate type) {
         return null;
     }
 
@@ -33,6 +34,16 @@ public class FakeActivityHistoryRepository implements ActivityHistoryRepository 
 
     @Override
     public List<ActivityScore> getActivityDailyGraph(Long memberId, LocalDate start, LocalDate end) {
+        return null;
+    }
+
+    @Override
+    public List<ActivityScore> getActivityWeeklyGraph(Long memberId, LocalDate start, LocalDate end) {
+        return null;
+    }
+
+    @Override
+    public List<ActivityScore> getActivityMonthlyGraph(Long memberId, LocalDate start, LocalDate end) {
         return null;
     }
 


### PR DESCRIPTION
## 구현 내용
- 일별, 주별, 월별 활통 그래프 목록 조회 API 구현
- 어드민용 활동 히스토리 생성 API 구현
- BaseTimeEntity에 @SuperBuilder 적용