### PR TITLE
앨범 목록 조회 성능 개선

### DIFF
--- a/src/main/java/com/project/singk/domain/activity/controller/ActivityHistoryController.java
+++ b/src/main/java/com/project/singk/domain/activity/controller/ActivityHistoryController.java
@@ -6,7 +6,7 @@ import com.project.singk.domain.activity.controller.response.ActivityGraphRespon
 import com.project.singk.domain.activity.controller.response.ActivityHistoryResponse;
 import com.project.singk.domain.member.controller.port.AuthService;
 import com.project.singk.global.api.BaseResponse;
-import com.project.singk.global.api.PageResponse;
+import com.project.singk.global.api.OffsetPageResponse;
 import com.project.singk.global.validate.Date;
 import com.project.singk.global.validate.ValidEnum;
 import lombok.RequiredArgsConstructor;
@@ -42,7 +42,7 @@ public class ActivityHistoryController {
     }
 
     @GetMapping("/list")
-    public BaseResponse<PageResponse<ActivityHistoryResponse>> getActivityHistories(
+    public BaseResponse<OffsetPageResponse<ActivityHistoryResponse>> getActivityHistories(
             @Range(min = 0, max = 1000, message = "offset은 0에서 1000사이의 값 이어야 합니다.") @RequestParam("offset") int offset,
             @Range(min = 0, max = 50, message = "limit은 0에서 50사이의 값 이어야 합니다.") @RequestParam("limit") int limit
     ) {

--- a/src/main/java/com/project/singk/domain/activity/controller/port/ActivityHistoryService.java
+++ b/src/main/java/com/project/singk/domain/activity/controller/port/ActivityHistoryService.java
@@ -2,13 +2,13 @@ package com.project.singk.domain.activity.controller.port;
 
 import com.project.singk.domain.activity.controller.response.ActivityGraphResponse;
 import com.project.singk.domain.activity.controller.response.ActivityHistoryResponse;
-import com.project.singk.global.api.PageResponse;
+import com.project.singk.global.api.OffsetPageResponse;
 
 import java.util.List;
 
 public interface ActivityHistoryService {
     List<ActivityGraphResponse> getActivityGraph(Long memberId, String startDate, String endDate, String dateType);
-    PageResponse<ActivityHistoryResponse> getActivityHistories(Long memberId, int offset, int limit);
+    OffsetPageResponse<ActivityHistoryResponse> getActivityHistories(Long memberId, int offset, int limit);
     List<ActivityGraphResponse> getDailyActivityGraph(Long memberId, String startDate, String endDate);
     List<ActivityGraphResponse> getWeeklyActivityGraph(Long memberId, String startDate, String endDate);
 

--- a/src/main/java/com/project/singk/domain/activity/service/ActivityHistoryServiceImpl.java
+++ b/src/main/java/com/project/singk/domain/activity/service/ActivityHistoryServiceImpl.java
@@ -6,7 +6,7 @@ import com.project.singk.domain.activity.controller.response.ActivityGraphRespon
 import com.project.singk.domain.activity.controller.response.ActivityHistoryResponse;
 import com.project.singk.domain.activity.domain.ActivityHistory;
 import com.project.singk.domain.activity.service.port.ActivityHistoryRepository;
-import com.project.singk.global.api.PageResponse;
+import com.project.singk.global.api.OffsetPageResponse;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -42,10 +42,10 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
     }
 
     @Override
-    public PageResponse<ActivityHistoryResponse> getActivityHistories(Long memberId, int offset, int limit) {
+    public OffsetPageResponse<ActivityHistoryResponse> getActivityHistories(Long memberId, int offset, int limit) {
         Page<ActivityHistory> activityHistories = activityHistoryRepository.getActivityHistories(memberId, offset, limit);
 
-        return PageResponse.of(
+        return OffsetPageResponse.of(
                 offset,
                 limit,
                 (int) activityHistories.getTotalElements(),

--- a/src/main/java/com/project/singk/domain/admin/controller/CreateAdminController.java
+++ b/src/main/java/com/project/singk/domain/admin/controller/CreateAdminController.java
@@ -5,7 +5,7 @@ import com.project.singk.domain.admin.controller.port.AdminService;
 import com.project.singk.domain.album.controller.response.AlbumDetailResponse;
 import com.project.singk.domain.member.controller.port.AuthService;
 import com.project.singk.global.api.BaseResponse;
-import com.project.singk.global.api.PageResponse;
+import com.project.singk.global.api.OffsetPageResponse;
 import com.project.singk.global.validate.Date;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Range;
@@ -23,7 +23,7 @@ public class CreateAdminController {
 	private final AdminService adminService;
     private final AuthService authService;
 	@PostMapping("/albums")
-	public BaseResponse<PageResponse<AlbumDetailResponse>> createAlbums(
+	public BaseResponse<OffsetPageResponse<AlbumDetailResponse>> createAlbums(
 		@RequestParam(value = "query", required = false) String query,
 		@Range(min = 0, max = 1000, message = "offset은 0에서 1000사이의 값 이어야 합니다.") @RequestParam("offset") int offset,
 		@Range(min = 0, max = 50, message = "limit은 0에서 50사이의 값 이어야 합니다.") @RequestParam("limit") int limit

--- a/src/main/java/com/project/singk/domain/admin/controller/DeleteAdminController.java
+++ b/src/main/java/com/project/singk/domain/admin/controller/DeleteAdminController.java
@@ -1,16 +1,10 @@
 package com.project.singk.domain.admin.controller;
 
 import com.project.singk.domain.admin.controller.port.AdminService;
-import com.project.singk.domain.album.controller.response.AlbumDetailResponse;
-import com.project.singk.domain.member.controller.response.MemberResponse;
 import com.project.singk.global.api.BaseResponse;
-import com.project.singk.global.api.PageResponse;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.validator.constraints.Range;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @Validated
 @RestController

--- a/src/main/java/com/project/singk/domain/admin/controller/GetAdminController.java
+++ b/src/main/java/com/project/singk/domain/admin/controller/GetAdminController.java
@@ -1,10 +1,12 @@
 package com.project.singk.domain.admin.controller;
 
 import com.project.singk.domain.admin.controller.port.AdminService;
-import com.project.singk.domain.album.controller.response.AlbumDetailResponse;
+import com.project.singk.domain.album.controller.response.AlbumListResponse;
 import com.project.singk.domain.member.controller.response.MemberResponse;
 import com.project.singk.global.api.BaseResponse;
-import com.project.singk.global.api.PageResponse;
+import com.project.singk.global.api.CursorPageResponse;
+import com.project.singk.global.api.OffsetPageResponse;
+import com.project.singk.global.validate.Date;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Range;
 import org.springframework.validation.annotation.Validated;
@@ -23,5 +25,33 @@ public class GetAdminController {
     @GetMapping("/members")
     public BaseResponse<List<MemberResponse>> getMembers() {
         return BaseResponse.ok(adminService.getMembers());
+    }
+
+    @GetMapping("/albums")
+    public BaseResponse<List<AlbumListResponse>> getAlbums() {
+        return BaseResponse.ok(adminService.getAlbums());
+    }
+
+    @GetMapping("/albums/offset")
+    public BaseResponse<OffsetPageResponse<AlbumListResponse>> getAlbumsWithOffset(
+            @RequestParam("offset") int offset,
+            @RequestParam("limit") int limit
+    ) {
+        return BaseResponse.ok(adminService.getAlbumsWithOffsetPaging(
+                offset,
+                limit
+        ));
+    }
+    @GetMapping("/albums/cursor")
+    public BaseResponse<CursorPageResponse<AlbumListResponse>> getAlbumsWithCursor(
+            @RequestParam(value = "cursor-id", required = false) Long cursorId,
+            @Date @RequestParam(value = "cursor-date", required = false) String cursorDate,
+            @Range(min = 0, max = 50, message = "limit은 0에서 50사이의 값 이어야 합니다.") @RequestParam("limit") int limit
+    ) {
+        return BaseResponse.ok(adminService.getAlbumsWithCursorPaging(
+                cursorId,
+                cursorDate,
+                limit
+        ));
     }
 }

--- a/src/main/java/com/project/singk/domain/admin/controller/port/AdminService.java
+++ b/src/main/java/com/project/singk/domain/admin/controller/port/AdminService.java
@@ -2,14 +2,19 @@ package com.project.singk.domain.admin.controller.port;
 
 import com.project.singk.domain.activity.controller.response.ActivityHistoryResponse;
 import com.project.singk.domain.album.controller.response.AlbumDetailResponse;
+import com.project.singk.domain.album.controller.response.AlbumListResponse;
 import com.project.singk.domain.member.controller.response.MemberResponse;
-import com.project.singk.global.api.PageResponse;
+import com.project.singk.global.api.CursorPageResponse;
+import com.project.singk.global.api.OffsetPageResponse;
 
 import java.util.List;
 
 public interface AdminService {
-    PageResponse<AlbumDetailResponse> createAlbums(String query, int offset, int limit);
+    OffsetPageResponse<AlbumDetailResponse> createAlbums(String query, int offset, int limit);
     void deleteMember(Long memberId);
     List<MemberResponse> getMembers();
+    List<AlbumListResponse> getAlbums();
+    OffsetPageResponse<AlbumListResponse> getAlbumsWithOffsetPaging(int offset, int limit);
+    CursorPageResponse<AlbumListResponse> getAlbumsWithCursorPaging(Long cursorId, String cursorDate, int limit);
     List<ActivityHistoryResponse> createActivityHistories(Long memberId, String startDate, String endDate, int count);
 }

--- a/src/main/java/com/project/singk/domain/album/controller/AlbumController.java
+++ b/src/main/java/com/project/singk/domain/album/controller/AlbumController.java
@@ -1,6 +1,6 @@
 package com.project.singk.domain.album.controller;
 
-import com.project.singk.domain.album.controller.request.AlbumSort;
+import com.project.singk.global.api.CursorPageResponse;
 import com.project.singk.global.validate.Date;
 import com.project.singk.global.validate.ValidDecimal;
 import org.hibernate.validator.constraints.Range;
@@ -15,7 +15,7 @@ import com.project.singk.domain.album.controller.port.AlbumService;
 import com.project.singk.domain.album.controller.response.AlbumDetailResponse;
 import com.project.singk.domain.album.controller.response.AlbumListResponse;
 import com.project.singk.global.api.BaseResponse;
-import com.project.singk.global.api.PageResponse;
+import com.project.singk.global.api.OffsetPageResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -35,7 +35,7 @@ public class AlbumController {
 	}
 
 	@GetMapping("/search")
-	public BaseResponse<PageResponse<AlbumListResponse>> searchAlbums(
+	public BaseResponse<OffsetPageResponse<AlbumListResponse>> searchAlbums(
 		@RequestParam(value = "query", required = false) String query,
 		@Range(min = 0, max = 1000, message = "offset은 0에서 1000사이의 값 이어야 합니다.") @RequestParam("offset") int offset,
 		@Range(min = 0, max = 50, message = "limit은 0에서 50사이의 값 이어야 합니다.") @RequestParam("limit") int limit
@@ -44,8 +44,8 @@ public class AlbumController {
 	}
 
     @GetMapping("/list/recent")
-    public BaseResponse<PageResponse<AlbumListResponse>> getAlbumsByDate(
-            @RequestParam(value = "cursor-id", required = false) String cursorId,
+    public BaseResponse<CursorPageResponse<AlbumListResponse>> getAlbumsByDate(
+            @RequestParam(value = "cursor-id", required = false) Long cursorId,
             @Date @RequestParam(value = "cursor-date", required = false) String cursorDate,
             @Range(min = 0, max = 50, message = "limit은 0에서 50사이의 값 이어야 합니다.") @RequestParam("limit") int limit
     ) {
@@ -53,8 +53,8 @@ public class AlbumController {
     }
 
     @GetMapping("/list/average-score")
-    public BaseResponse<PageResponse<AlbumListResponse>> getAlbumsByAverage(
-            @RequestParam(value = "cursor-id", required = false) String cursorId,
+    public BaseResponse<CursorPageResponse<AlbumListResponse>> getAlbumsByAverage(
+            @RequestParam(value = "cursor-id", required = false) Long cursorId,
             @ValidDecimal @RequestParam(value = "cursor-score", required = false) String cursorScore,
             @Range(min = 0, max = 50, message = "limit은 0에서 50사이의 값 이어야 합니다.") @RequestParam("limit") int limit
     ) {
@@ -62,8 +62,8 @@ public class AlbumController {
         return BaseResponse.ok(albumService.getAlbumsByAverageScore(cursorId, cursorScore, limit));
     }
     @GetMapping("/list/review-count")
-    public BaseResponse<PageResponse<AlbumListResponse>> getAlbumsByReviewCount(
-            @RequestParam(value = "cursor-id", required = false) String cursorId,
+    public BaseResponse<CursorPageResponse<AlbumListResponse>> getAlbumsByReviewCount(
+            @RequestParam(value = "cursor-id", required = false) Long cursorId,
             @RequestParam(value = "cursor-review-count", required = false) String cursorReviewCount,
             @Range(min = 0, max = 50, message = "limit은 0에서 50사이의 값 이어야 합니다.") @RequestParam("limit") int limit
     ) {

--- a/src/main/java/com/project/singk/domain/album/controller/port/AlbumService.java
+++ b/src/main/java/com/project/singk/domain/album/controller/port/AlbumService.java
@@ -1,14 +1,14 @@
 package com.project.singk.domain.album.controller.port;
 
-import com.project.singk.domain.album.controller.request.AlbumSort;
 import com.project.singk.domain.album.controller.response.AlbumDetailResponse;
 import com.project.singk.domain.album.controller.response.AlbumListResponse;
-import com.project.singk.global.api.PageResponse;
+import com.project.singk.global.api.CursorPageResponse;
+import com.project.singk.global.api.OffsetPageResponse;
 
 public interface AlbumService {
 	AlbumDetailResponse getAlbum(String id);
-	PageResponse<AlbumListResponse> searchAlbums(String query, int offset, int limit);
-	PageResponse<AlbumListResponse> getAlbumsByDate(String cursorId, String cursorDate, int limit);
-	PageResponse<AlbumListResponse> getAlbumsByAverageScore(String cursorId, String cursorScore, int limit);
-	PageResponse<AlbumListResponse> getAlbumsByReviewCount(String cursorId, String cursorReviewCount, int limit);
+	OffsetPageResponse<AlbumListResponse> searchAlbums(String query, int offset, int limit);
+	CursorPageResponse<AlbumListResponse> getAlbumsByDate(Long cursorId, String cursorDate, int limit);
+	CursorPageResponse<AlbumListResponse> getAlbumsByAverageScore(Long cursorId, String cursorScore, int limit);
+	CursorPageResponse<AlbumListResponse> getAlbumsByReviewCount(Long cursorId, String cursorReviewCount, int limit);
 }

--- a/src/main/java/com/project/singk/domain/album/controller/response/AlbumListResponse.java
+++ b/src/main/java/com/project/singk/domain/album/controller/response/AlbumListResponse.java
@@ -8,6 +8,8 @@ import com.project.singk.domain.album.domain.Album;
 
 import com.project.singk.domain.album.domain.AlbumArtist;
 import com.project.singk.domain.album.domain.AlbumSimplified;
+import com.project.singk.domain.review.controller.response.AlbumReviewStatisticsResponse;
+import com.project.singk.domain.review.controller.response.AlbumReviewStatisticsSimpleResponse;
 import lombok.*;
 
 @Getter
@@ -20,8 +22,7 @@ public class AlbumListResponse {
 	private String name;
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
 	private LocalDateTime releasedAt;
-    private long count;
-    private double averageScore;
+    private AlbumReviewStatisticsSimpleResponse statistics;
 	private List<ArtistResponse> artists;
 	private List<ImageResponse> images;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
@@ -40,8 +41,7 @@ public class AlbumListResponse {
 			.images(album.getImages().stream()
 				.map(ImageResponse::from)
 				.toList())
-            .count(album.getStatistics().getTotalReviewer())
-            .averageScore(album.getStatistics().getAverageScore())
+            .statistics(AlbumReviewStatisticsSimpleResponse.from(album.getStatistics()))
             .modifiedAt(album.getStatistics().getModifiedAt())
 			.build();
 	}

--- a/src/main/java/com/project/singk/domain/album/controller/response/AlbumListResponse.java
+++ b/src/main/java/com/project/singk/domain/album/controller/response/AlbumListResponse.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.project.singk.domain.album.domain.Album;
 
 import com.project.singk.domain.album.domain.AlbumArtist;
+import com.project.singk.domain.album.domain.AlbumSimplified;
 import lombok.*;
 
 @Getter
@@ -26,7 +27,7 @@ public class AlbumListResponse {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime modifiedAt;
 
-	public static AlbumListResponse from (Album album) {
+	public static AlbumListResponse from (AlbumSimplified album) {
 
 		return AlbumListResponse.builder()
 			.id(album.getId())

--- a/src/main/java/com/project/singk/domain/album/domain/AlbumSimplified.java
+++ b/src/main/java/com/project/singk/domain/album/domain/AlbumSimplified.java
@@ -1,0 +1,31 @@
+package com.project.singk.domain.album.domain;
+
+import com.project.singk.domain.review.domain.AlbumReviewStatistics;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class AlbumSimplified {
+	private final String id;
+	private final String name;
+	private final AlbumType type;
+	private final LocalDateTime releasedAt;
+    private final List<AlbumArtist> artists;
+    private final List<AlbumImage> images;
+    private final AlbumReviewStatistics statistics;
+    private final LocalDateTime createdAt;
+    @Builder
+    public AlbumSimplified(String id, String name, AlbumType type, LocalDateTime releasedAt, List<AlbumArtist> artists, List<AlbumImage> images, AlbumReviewStatistics statistics, LocalDateTime createdAt) {
+        this.id = id;
+        this.name = name;
+        this.type = type;
+        this.releasedAt = releasedAt;
+        this.artists = artists;
+        this.images = images;
+        this.statistics = statistics;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/project/singk/domain/album/infrastructure/AlbumRepositoryImpl.java
+++ b/src/main/java/com/project/singk/domain/album/infrastructure/AlbumRepositoryImpl.java
@@ -5,6 +5,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 
+import com.project.singk.domain.album.domain.AlbumSimplified;
 import com.project.singk.domain.album.infrastructure.entity.*;
 import com.project.singk.domain.album.infrastructure.jpa.AlbumJpaRepository;
 import com.project.singk.domain.review.domain.AlbumReviewStatistics;
@@ -96,15 +97,15 @@ public class AlbumRepositoryImpl implements AlbumRepository {
 	}
 
     @Override
-    public Page<Album> findAllByModifiedAt(String cursorId, String cursorDate, int limit) {
-        List<Album> albums = jpaQueryFactory.select(albumEntity)
+    public Page<AlbumSimplified> findAllByModifiedAt(String cursorId, String cursorDate, int limit) {
+        List<AlbumSimplified> albums = jpaQueryFactory.select(albumEntity)
                 .from(albumEntity)
                 .innerJoin(albumEntity.statistics, albumReviewStatisticsEntity).fetchJoin()
                 .where(cursorByDate(cursorId, cursorDate))
                 .orderBy(albumReviewStatisticsEntity.modifiedAt.desc(), albumEntity.id.asc())
                 .limit(limit)
                 .fetch().stream()
-                .map(AlbumEntity::toModel)
+                .map(AlbumEntity::simplified)
                 .toList();
 
         long count = jpaQueryFactory.select(albumEntity.count())
@@ -130,16 +131,16 @@ public class AlbumRepositoryImpl implements AlbumRepository {
     }
 
     @Override
-    public Page<Album> findAllByAverageScore(String cursorId, String cursorScore, int limit) {
+    public Page<AlbumSimplified> findAllByAverageScore(String cursorId, String cursorScore, int limit) {
 
-        List<Album> albums = jpaQueryFactory.select(albumEntity)
+        List<AlbumSimplified> albums = jpaQueryFactory.select(albumEntity)
                 .from(albumEntity)
                 .innerJoin(albumEntity.statistics, albumReviewStatisticsEntity).fetchJoin()
                 .where(cursorByAverage(cursorId, cursorScore))
                 .orderBy(albumReviewStatisticsEntity.averageScore.desc(), albumEntity.id.asc())
                 .limit(limit)
                 .fetch().stream()
-                .map(AlbumEntity::toModel)
+                .map(AlbumEntity::simplified)
                 .toList();
 
         // TODO : 카운트 쿼리 최적화
@@ -164,15 +165,15 @@ public class AlbumRepositoryImpl implements AlbumRepository {
     }
 
     @Override
-    public Page<Album> findAllByReviewCount(String cursorId, String cursorReviewCount, int limit) {
-        List<Album> albums = jpaQueryFactory.select(albumEntity)
+    public Page<AlbumSimplified> findAllByReviewCount(String cursorId, String cursorReviewCount, int limit) {
+        List<AlbumSimplified> albums = jpaQueryFactory.select(albumEntity)
                 .from(albumEntity)
                 .innerJoin(albumEntity.statistics, albumReviewStatisticsEntity).fetchJoin()
                 .where(cursorByReviewCount(cursorId, cursorReviewCount))
                 .orderBy(albumReviewStatisticsEntity.totalReviewer.desc(), albumEntity.id.asc())
                 .limit(limit)
                 .fetch().stream()
-                .map(AlbumEntity::toModel)
+                .map(AlbumEntity::simplified)
                 .toList();
 
         long count = jpaQueryFactory.select(albumEntity.count())

--- a/src/main/java/com/project/singk/domain/album/infrastructure/AlbumRepositoryImpl.java
+++ b/src/main/java/com/project/singk/domain/album/infrastructure/AlbumRepositoryImpl.java
@@ -34,7 +34,7 @@ import static com.project.singk.domain.review.infrastructure.QAlbumReviewStatist
 @RequiredArgsConstructor
 public class AlbumRepositoryImpl implements AlbumRepository {
 	private final AlbumJpaRepository albumJpaRepository;
-    private final JPAQueryFactory jpaQueryFactory;
+    private final JPAQueryFactory queryFactory;
 
 	@Override
 	public Album save(Album album) {
@@ -58,6 +58,47 @@ public class AlbumRepositoryImpl implements AlbumRepository {
 	}
 
     @Override
+    public List<AlbumSimplified> findAll() {
+        return queryFactory.selectFrom(albumEntity)
+                .innerJoin(albumEntity.statistics, albumReviewStatisticsEntity).fetchJoin()
+                .fetch().stream()
+                .map(AlbumEntity::simplified)
+                .toList();
+    }
+
+    @Override
+    public Page<AlbumSimplified> findAllWithOffsetPaging(int offset, int limit) {
+        List<AlbumSimplified> albums = queryFactory.selectFrom(albumEntity)
+                .innerJoin(albumEntity.statistics, albumReviewStatisticsEntity).fetchJoin()
+                .offset(offset)
+                .limit(limit)
+                .orderBy(albumReviewStatisticsEntity.modifiedAt.desc())
+                .fetch().stream()
+                .map(AlbumEntity::simplified)
+                .toList();
+
+        Long count = queryFactory.select(albumEntity.count())
+                .from(albumEntity)
+                .fetchOne();
+
+        Pageable pageable = PageRequest.ofSize(limit);
+
+        return new PageImpl<>(albums, pageable, count);
+    }
+
+    @Override
+    public List<AlbumSimplified> findAllWithCursorPaging(Long cursorId, String cursorDate, int limit) {
+        return queryFactory.selectFrom(albumEntity)
+                .innerJoin(albumEntity.statistics, albumReviewStatisticsEntity).fetchJoin()
+                .where(cursorByDate(cursorId, cursorDate))
+                .limit(limit)
+                .orderBy(albumReviewStatisticsEntity.modifiedAt.desc())
+                .fetch().stream()
+                .map(AlbumEntity::simplified)
+                .toList();
+    }
+
+    @Override
     public Album getByIdWithStatistics(String albumId) {
         return findByIdWithStatistics(albumId)
                 .orElseThrow(() -> new ApiException(AppHttpStatus.NOT_FOUND_ALBUM));
@@ -66,7 +107,7 @@ public class AlbumRepositoryImpl implements AlbumRepository {
     @Override
     public AlbumReviewStatistics getAlbumReviewStatisticsByAlbumId(String albumId) {
 
-        return jpaQueryFactory.select(albumReviewStatisticsEntity)
+        return queryFactory.select(albumReviewStatisticsEntity)
                 .from(albumEntity)
                 .innerJoin(albumEntity.statistics, albumReviewStatisticsEntity)
                 .where(albumEntity.id.eq(albumId))
@@ -76,7 +117,7 @@ public class AlbumRepositoryImpl implements AlbumRepository {
 
     @Override
     public Optional<Album> findByIdWithStatistics(String albumId) {
-        return Optional.ofNullable(jpaQueryFactory.select(albumEntity)
+        return Optional.ofNullable(queryFactory.select(albumEntity)
                 .from(albumEntity)
                 .where(albumEntity.id.eq(albumId))
                 .innerJoin(albumEntity.statistics, albumReviewStatisticsEntity).fetchJoin()
@@ -86,7 +127,7 @@ public class AlbumRepositoryImpl implements AlbumRepository {
 
     @Override
 	public Optional<Album> findById(String id) {
-        return Optional.ofNullable(jpaQueryFactory
+        return Optional.ofNullable(queryFactory
                 .selectFrom(albumEntity)
                 .where(albumEntity.id.eq(id))
                 .leftJoin(albumEntity.tracks, trackEntity)
@@ -97,27 +138,18 @@ public class AlbumRepositoryImpl implements AlbumRepository {
 	}
 
     @Override
-    public Page<AlbumSimplified> findAllByModifiedAt(String cursorId, String cursorDate, int limit) {
-        List<AlbumSimplified> albums = jpaQueryFactory.select(albumEntity)
-                .from(albumEntity)
+    public List<AlbumSimplified> findAllByModifiedAt(Long cursorId, String cursorDate, int limit) {
+        return queryFactory.selectFrom(albumEntity)
                 .innerJoin(albumEntity.statistics, albumReviewStatisticsEntity).fetchJoin()
                 .where(cursorByDate(cursorId, cursorDate))
-                .orderBy(albumReviewStatisticsEntity.modifiedAt.desc(), albumEntity.id.asc())
+                .orderBy(albumReviewStatisticsEntity.modifiedAt.desc())
                 .limit(limit)
                 .fetch().stream()
                 .map(AlbumEntity::simplified)
                 .toList();
-
-        long count = jpaQueryFactory.select(albumEntity.count())
-                .from(albumEntity)
-                .fetchOne();
-
-        Pageable pageable = PageRequest.ofSize(limit);
-
-        return new PageImpl<>(albums, pageable, count);
     }
 
-    private BooleanExpression cursorByDate(String cursorId, String cursorDate) {
+    private BooleanExpression cursorByDate(Long cursorId, String cursorDate) {
         if (cursorId == null || cursorDate == null) {
             return null;
         }
@@ -126,47 +158,38 @@ public class AlbumRepositoryImpl implements AlbumRepository {
         LocalDateTime date = LocalDateTime.parse(cursorDate, formatter);
 
         return albumReviewStatisticsEntity.modifiedAt.eq(date)
-                .and(albumEntity.id.gt(cursorId))
+                .and(albumReviewStatisticsEntity.id.gt(cursorId))
                 .or(albumReviewStatisticsEntity.modifiedAt.lt(date));
     }
 
     @Override
-    public Page<AlbumSimplified> findAllByAverageScore(String cursorId, String cursorScore, int limit) {
-
-        List<AlbumSimplified> albums = jpaQueryFactory.select(albumEntity)
+    public List<AlbumSimplified> findAllByAverageScore(Long cursorId, String cursorScore, int limit) {
+        return queryFactory.select(albumEntity)
                 .from(albumEntity)
                 .innerJoin(albumEntity.statistics, albumReviewStatisticsEntity).fetchJoin()
                 .where(cursorByAverage(cursorId, cursorScore))
-                .orderBy(albumReviewStatisticsEntity.averageScore.desc(), albumEntity.id.asc())
+                .orderBy(albumReviewStatisticsEntity.averageScore.desc())
                 .limit(limit)
                 .fetch().stream()
                 .map(AlbumEntity::simplified)
                 .toList();
-
-        // TODO : 카운트 쿼리 최적화
-        long count = jpaQueryFactory.select(albumEntity.count())
-                .from(albumEntity)
-                .fetchOne();
-
-        Pageable pageable = PageRequest.ofSize(limit);
-
-        return new PageImpl<>(albums, pageable, count);
     }
 
-    private BooleanExpression cursorByAverage(String cursorId, String cursorScore) {
+    private BooleanExpression cursorByAverage(Long cursorId, String cursorScore) {
         if (cursorId == null || cursorScore == null) {
             return null;
         }
 
         double score = Double.parseDouble(cursorScore);
+
         return albumReviewStatisticsEntity.averageScore.eq(score)
-                .and(albumEntity.id.gt(cursorId))
+                .and(albumReviewStatisticsEntity.id.gt(cursorId))
                 .or(albumReviewStatisticsEntity.averageScore.lt(score));
     }
 
     @Override
-    public Page<AlbumSimplified> findAllByReviewCount(String cursorId, String cursorReviewCount, int limit) {
-        List<AlbumSimplified> albums = jpaQueryFactory.select(albumEntity)
+    public List<AlbumSimplified> findAllByReviewCount(Long cursorId, String cursorReviewCount, int limit) {
+        return queryFactory.select(albumEntity)
                 .from(albumEntity)
                 .innerJoin(albumEntity.statistics, albumReviewStatisticsEntity).fetchJoin()
                 .where(cursorByReviewCount(cursorId, cursorReviewCount))
@@ -175,23 +198,15 @@ public class AlbumRepositoryImpl implements AlbumRepository {
                 .fetch().stream()
                 .map(AlbumEntity::simplified)
                 .toList();
-
-        long count = jpaQueryFactory.select(albumEntity.count())
-                .from(albumEntity)
-                .fetchOne();
-
-        Pageable pageable = PageRequest.ofSize(limit);
-
-        return new PageImpl<>(albums, pageable, count);
     }
-    private BooleanExpression cursorByReviewCount(String cursorId, String cursorReviewCount) {
+    private BooleanExpression cursorByReviewCount(Long cursorId, String cursorReviewCount) {
         if (cursorId == null || cursorReviewCount == null) {
             return null;
         }
         int reviewCount = Integer.parseInt(cursorReviewCount);
 
         return albumReviewStatisticsEntity.totalReviewer.eq(reviewCount)
-                .and(albumEntity.id.gt(cursorId))
+                .and(albumReviewStatisticsEntity.id.gt(cursorId))
                 .or(albumReviewStatisticsEntity.totalReviewer.lt(reviewCount));
     }
 

--- a/src/main/java/com/project/singk/domain/album/infrastructure/SpotifyRepositoryImpl.java
+++ b/src/main/java/com/project/singk/domain/album/infrastructure/SpotifyRepositoryImpl.java
@@ -12,7 +12,7 @@ import com.project.singk.domain.album.infrastructure.spotify.AlbumSimplifiedEnti
 import com.project.singk.domain.album.service.port.SpotifyRepository;
 import com.project.singk.global.api.ApiException;
 import com.project.singk.global.api.AppHttpStatus;
-import com.project.singk.global.api.PageResponse;
+import com.project.singk.global.api.OffsetPageResponse;
 
 import lombok.RequiredArgsConstructor;
 import se.michaelthelin.spotify.SpotifyApi;
@@ -42,7 +42,7 @@ public class SpotifyRepositoryImpl implements SpotifyRepository {
 	}
 
 	@Override
-	public PageResponse<AlbumSimplifiedEntity> searchAlbums(String query, int offset, int limit) {
+	public OffsetPageResponse<AlbumSimplifiedEntity> searchAlbums(String query, int offset, int limit) {
 		final SearchAlbumsRequest searchAlbumsRequest = spotifyApi.searchAlbums(query)
 			.limit(limit)
 			.offset(offset)
@@ -51,7 +51,7 @@ public class SpotifyRepositoryImpl implements SpotifyRepository {
 
 		try {
 			Paging<AlbumSimplified> albums = searchAlbumsRequest.execute();
-			return PageResponse.of(
+			return OffsetPageResponse.of(
 				offset,
 				limit,
 				albums.getTotal(),

--- a/src/main/java/com/project/singk/domain/album/infrastructure/entity/AlbumEntity.java
+++ b/src/main/java/com/project/singk/domain/album/infrastructure/entity/AlbumEntity.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.project.singk.domain.album.domain.Album;
+import com.project.singk.domain.album.domain.AlbumSimplified;
 import com.project.singk.domain.album.domain.AlbumType;
 import com.project.singk.domain.review.infrastructure.AlbumReviewStatisticsEntity;
 import com.project.singk.global.domain.BaseTimeEntity;
@@ -35,19 +36,19 @@ public class AlbumEntity extends BaseTimeEntity implements Persistable<String> {
 	private LocalDateTime releasedAt;
 
     @JoinColumn(name = "album_id", updatable = false, nullable = false)
-    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<TrackEntity> tracks;
 
     @JoinColumn(name = "album_id", updatable = false, nullable = false)
-    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<AlbumImageEntity> images;
 
     @JoinColumn(name = "album_id", updatable = false, nullable = false)
-    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<AlbumArtistEntity> artists;
 
     @JoinColumn(name = "statistic_id")
-    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private AlbumReviewStatisticsEntity statistics;
 
     @Transient
@@ -86,6 +87,19 @@ public class AlbumEntity extends BaseTimeEntity implements Persistable<String> {
 			.type(this.type)
 			.releasedAt(this.releasedAt)
             .tracks(this.tracks.stream().map(TrackEntity::toModel).toList())
+            .images(this.images.stream().map(AlbumImageEntity::toModel).toList())
+            .artists(this.artists.stream().map(AlbumArtistEntity::toModel).toList())
+            .statistics(this.statistics.toModel())
+            .createdAt(this.getCreatedAt())
+			.build();
+	}
+
+    public AlbumSimplified simplified() {
+		return AlbumSimplified.builder()
+			.id(this.id)
+			.name(this.name)
+			.type(this.type)
+			.releasedAt(this.releasedAt)
             .images(this.images.stream().map(AlbumImageEntity::toModel).toList())
             .artists(this.artists.stream().map(AlbumArtistEntity::toModel).toList())
             .statistics(this.statistics.toModel())

--- a/src/main/java/com/project/singk/domain/album/infrastructure/entity/TrackEntity.java
+++ b/src/main/java/com/project/singk/domain/album/infrastructure/entity/TrackEntity.java
@@ -38,7 +38,7 @@ public class TrackEntity extends BaseTimeEntity implements Persistable<String> {
 	private String previewUrl;
 
     @JoinColumn(name = "album_id", updatable = false, nullable = false)
-    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<TrackArtistEntity> artists;
 
     @Builder

--- a/src/main/java/com/project/singk/domain/album/infrastructure/entity/TrackEntity.java
+++ b/src/main/java/com/project/singk/domain/album/infrastructure/entity/TrackEntity.java
@@ -37,7 +37,7 @@ public class TrackEntity extends BaseTimeEntity implements Persistable<String> {
 	@Column(name = "preview_url")
 	private String previewUrl;
 
-    @JoinColumn(name = "album_id", updatable = false, nullable = false)
+    @JoinColumn(name = "track_id", updatable = false, nullable = false)
     @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<TrackArtistEntity> artists;
 

--- a/src/main/java/com/project/singk/domain/album/infrastructure/spotify/AlbumSimplifiedEntity.java
+++ b/src/main/java/com/project/singk/domain/album/infrastructure/spotify/AlbumSimplifiedEntity.java
@@ -63,4 +63,18 @@ public class AlbumSimplifiedEntity {
             .statistics(AlbumReviewStatistics.empty())
 			.build();
 	}
+
+    public com.project.singk.domain.album.domain.AlbumSimplified simplified() {
+		return com.project.singk.domain.album.domain.AlbumSimplified.builder()
+			.id(this.id)
+			.name(this.name)
+			.releasedAt(this.releasedAt)
+            .artists(this.artists.stream()
+                    .map(ArtistSimplifiedEntity::toModel)
+                    .map(AlbumArtist::from)
+                    .toList())
+            .images(this.images.stream().map(ImageEntity::toModel).toList())
+            .statistics(AlbumReviewStatistics.empty())
+			.build();
+	}
 }

--- a/src/main/java/com/project/singk/domain/album/service/AlbumServiceImpl.java
+++ b/src/main/java/com/project/singk/domain/album/service/AlbumServiceImpl.java
@@ -4,10 +4,10 @@ import com.project.singk.domain.album.domain.*;
 import com.project.singk.domain.album.infrastructure.spotify.*;
 import com.project.singk.domain.album.service.port.*;
 import com.project.singk.domain.review.domain.AlbumReviewStatistics;
-import com.project.singk.global.api.PageResponse;
+import com.project.singk.global.api.CursorPageResponse;
+import com.project.singk.global.api.OffsetPageResponse;
 import lombok.Builder;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +18,7 @@ import com.project.singk.domain.album.controller.response.AlbumListResponse;
 import lombok.RequiredArgsConstructor;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Service
@@ -76,12 +77,12 @@ public class AlbumServiceImpl implements AlbumService {
 
     @Override
 	@Transactional(readOnly = true)
-	public PageResponse<AlbumListResponse> searchAlbums(String query, int offset, int limit) {
+	public OffsetPageResponse<AlbumListResponse> searchAlbums(String query, int offset, int limit) {
 		// 앨범 목록 API 요청 준비
 
-		PageResponse<AlbumSimplifiedEntity> spotifyAlbums = spotifyRepository.searchAlbums(query, offset, limit);
+		OffsetPageResponse<AlbumSimplifiedEntity> spotifyAlbums = spotifyRepository.searchAlbums(query, offset, limit);
 
-		return PageResponse.of(
+		return OffsetPageResponse.of(
                 spotifyAlbums.getOffset(),
                 spotifyAlbums.getLimit(),
                 spotifyAlbums.getTotal(),
@@ -95,12 +96,12 @@ public class AlbumServiceImpl implements AlbumService {
     @Override
     @Transactional(readOnly = true)
     @Cacheable(value = "albums_modified_at", key = "'albums_modified_at_'+ #cursorId + '_' + #cursorDate + '_' + #limit")
-    public PageResponse<AlbumListResponse> getAlbumsByDate(String cursorId, String cursorDate, int limit) {
-        Page<AlbumSimplified> albums = albumRepository.findAllByModifiedAt(cursorId, cursorDate, limit);
+    public CursorPageResponse<AlbumListResponse> getAlbumsByDate(Long cursorId, String cursorDate, int limit) {
+        List<AlbumSimplified> albums = albumRepository.findAllByModifiedAt(cursorId, cursorDate, limit);
 
-        return PageResponse.of(
+        return CursorPageResponse.of(
                 limit,
-                (int) albums.getTotalElements(),
+                albums.size() >= limit,
                 albums.stream()
                         .map(AlbumListResponse::from)
                         .toList()
@@ -110,11 +111,11 @@ public class AlbumServiceImpl implements AlbumService {
     @Override
     @Transactional(readOnly = true)
     @Cacheable(value = "albums_average_score", key = "'albums_average_score_'+ #cursorId + '_' + #cursorDate + '_' + #limit")
-    public PageResponse<AlbumListResponse> getAlbumsByAverageScore(String cursorId, String cursorScore, int limit) {
-        Page<AlbumSimplified> albums = albumRepository.findAllByAverageScore(cursorId, cursorScore, limit);
-        return PageResponse.of(
+    public CursorPageResponse<AlbumListResponse> getAlbumsByAverageScore(Long cursorId, String cursorScore, int limit) {
+        List<AlbumSimplified> albums = albumRepository.findAllByAverageScore(cursorId, cursorScore, limit);
+        return CursorPageResponse.of(
                 limit,
-                (int) albums.getTotalElements(),
+                albums.size() >= limit,
                 albums.stream()
                         .map(AlbumListResponse::from)
                         .toList()
@@ -124,11 +125,11 @@ public class AlbumServiceImpl implements AlbumService {
     @Override
     @Transactional(readOnly = true)
     @Cacheable(value = "albums_review_count", key = "'albums_review_count_'+ #cursorId + '_' + #cursorDate + '_' + #limit")
-    public PageResponse<AlbumListResponse> getAlbumsByReviewCount(String cursorId, String cursorReviewCount, int limit) {
-        Page<AlbumSimplified> albums = albumRepository.findAllByReviewCount(cursorId, cursorReviewCount, limit);
-        return PageResponse.of(
+    public CursorPageResponse<AlbumListResponse> getAlbumsByReviewCount(Long cursorId, String cursorReviewCount, int limit) {
+        List<AlbumSimplified> albums = albumRepository.findAllByReviewCount(cursorId, cursorReviewCount, limit);
+        return CursorPageResponse.of(
                 limit,
-                (int) albums.getTotalElements(),
+                albums.size() >= limit,
                 albums.stream()
                         .map(AlbumListResponse::from)
                         .toList()

--- a/src/main/java/com/project/singk/domain/album/service/AlbumServiceImpl.java
+++ b/src/main/java/com/project/singk/domain/album/service/AlbumServiceImpl.java
@@ -86,7 +86,7 @@ public class AlbumServiceImpl implements AlbumService {
                 spotifyAlbums.getLimit(),
                 spotifyAlbums.getTotal(),
                 spotifyAlbums.getItems().stream()
-                        .map(album -> AlbumListResponse.from(album.toModel()))
+                        .map(album -> AlbumListResponse.from(album.simplified()))
                         .toList()
 
 		);
@@ -96,7 +96,7 @@ public class AlbumServiceImpl implements AlbumService {
     @Transactional(readOnly = true)
     @Cacheable(value = "albums_modified_at", key = "'albums_modified_at_'+ #cursorId + '_' + #cursorDate + '_' + #limit")
     public PageResponse<AlbumListResponse> getAlbumsByDate(String cursorId, String cursorDate, int limit) {
-        Page<Album> albums = albumRepository.findAllByModifiedAt(cursorId, cursorDate, limit);
+        Page<AlbumSimplified> albums = albumRepository.findAllByModifiedAt(cursorId, cursorDate, limit);
 
         return PageResponse.of(
                 limit,
@@ -111,7 +111,7 @@ public class AlbumServiceImpl implements AlbumService {
     @Transactional(readOnly = true)
     @Cacheable(value = "albums_average_score", key = "'albums_average_score_'+ #cursorId + '_' + #cursorDate + '_' + #limit")
     public PageResponse<AlbumListResponse> getAlbumsByAverageScore(String cursorId, String cursorScore, int limit) {
-        Page<Album> albums = albumRepository.findAllByAverageScore(cursorId, cursorScore, limit);
+        Page<AlbumSimplified> albums = albumRepository.findAllByAverageScore(cursorId, cursorScore, limit);
         return PageResponse.of(
                 limit,
                 (int) albums.getTotalElements(),
@@ -125,7 +125,7 @@ public class AlbumServiceImpl implements AlbumService {
     @Transactional(readOnly = true)
     @Cacheable(value = "albums_review_count", key = "'albums_review_count_'+ #cursorId + '_' + #cursorDate + '_' + #limit")
     public PageResponse<AlbumListResponse> getAlbumsByReviewCount(String cursorId, String cursorReviewCount, int limit) {
-        Page<Album> albums = albumRepository.findAllByReviewCount(cursorId, cursorReviewCount, limit);
+        Page<AlbumSimplified> albums = albumRepository.findAllByReviewCount(cursorId, cursorReviewCount, limit);
         return PageResponse.of(
                 limit,
                 (int) albums.getTotalElements(),

--- a/src/main/java/com/project/singk/domain/album/service/port/AlbumRepository.java
+++ b/src/main/java/com/project/singk/domain/album/service/port/AlbumRepository.java
@@ -3,8 +3,8 @@ package com.project.singk.domain.album.service.port;
 import java.util.List;
 import java.util.Optional;
 
-import com.project.singk.domain.album.controller.request.AlbumSort;
 import com.project.singk.domain.album.domain.Album;
+import com.project.singk.domain.album.domain.AlbumSimplified;
 import com.project.singk.domain.review.domain.AlbumReviewStatistics;
 import org.springframework.data.domain.Page;
 
@@ -17,7 +17,7 @@ public interface AlbumRepository {
     AlbumReviewStatistics getAlbumReviewStatisticsByAlbumId(String albumId);
     Optional<Album> findByIdWithStatistics(String albumId);
 	Optional<Album> findById(String albumId);
-    Page<Album> findAllByModifiedAt(String cursorId, String cursorDate, int limit);
-    Page<Album> findAllByAverageScore(String cursorId, String cursorScore, int limit);
-    Page<Album> findAllByReviewCount(String cursorId, String cursorReviewCount, int limit);
+    Page<AlbumSimplified> findAllByModifiedAt(String cursorId, String cursorDate, int limit);
+    Page<AlbumSimplified> findAllByAverageScore(String cursorId, String cursorScore, int limit);
+    Page<AlbumSimplified> findAllByReviewCount(String cursorId, String cursorReviewCount, int limit);
 }

--- a/src/main/java/com/project/singk/domain/album/service/port/AlbumRepository.java
+++ b/src/main/java/com/project/singk/domain/album/service/port/AlbumRepository.java
@@ -13,11 +13,14 @@ public interface AlbumRepository {
     List<Album> saveAll(List<Album> albums);
     boolean existsById(String albumId);
 	Album getById(String albumId);
+    List<AlbumSimplified> findAll();
+    Page<AlbumSimplified> findAllWithOffsetPaging(int offset, int limit);
+    List<AlbumSimplified> findAllWithCursorPaging(Long cursorId, String cursorDate, int limit);
     Album getByIdWithStatistics(String albumId);
     AlbumReviewStatistics getAlbumReviewStatisticsByAlbumId(String albumId);
     Optional<Album> findByIdWithStatistics(String albumId);
 	Optional<Album> findById(String albumId);
-    Page<AlbumSimplified> findAllByModifiedAt(String cursorId, String cursorDate, int limit);
-    Page<AlbumSimplified> findAllByAverageScore(String cursorId, String cursorScore, int limit);
-    Page<AlbumSimplified> findAllByReviewCount(String cursorId, String cursorReviewCount, int limit);
+    List<AlbumSimplified> findAllByModifiedAt(Long cursorId, String cursorDate, int limit);
+    List<AlbumSimplified> findAllByAverageScore(Long cursorId, String cursorScore, int limit);
+    List<AlbumSimplified> findAllByReviewCount(Long cursorId, String cursorReviewCount, int limit);
 }

--- a/src/main/java/com/project/singk/domain/album/service/port/SpotifyRepository.java
+++ b/src/main/java/com/project/singk/domain/album/service/port/SpotifyRepository.java
@@ -2,9 +2,9 @@ package com.project.singk.domain.album.service.port;
 
 import com.project.singk.domain.album.infrastructure.spotify.AlbumEntity;
 import com.project.singk.domain.album.infrastructure.spotify.AlbumSimplifiedEntity;
-import com.project.singk.global.api.PageResponse;
+import com.project.singk.global.api.OffsetPageResponse;
 
 public interface SpotifyRepository {
 	AlbumEntity getAlbumById(String id);
-	PageResponse<AlbumSimplifiedEntity> searchAlbums(String query, int offset, int limit);
+	OffsetPageResponse<AlbumSimplifiedEntity> searchAlbums(String query, int offset, int limit);
 }

--- a/src/main/java/com/project/singk/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/project/singk/domain/review/controller/ReviewController.java
@@ -6,7 +6,7 @@ import com.project.singk.domain.review.controller.request.ReviewSort;
 import com.project.singk.domain.review.controller.response.AlbumReviewResponse;
 import com.project.singk.domain.review.controller.response.AlbumReviewStatisticsResponse;
 import com.project.singk.domain.review.controller.response.MyAlbumReviewResponse;
-import com.project.singk.global.api.PageResponse;
+import com.project.singk.global.api.OffsetPageResponse;
 import com.project.singk.global.validate.ValidEnum;
 import jakarta.validation.Valid;
 import org.hibernate.validator.constraints.Range;
@@ -18,8 +18,6 @@ import com.project.singk.global.api.BaseResponse;
 import com.project.singk.global.domain.PkResponseDto;
 
 import lombok.RequiredArgsConstructor;
-
-import java.util.List;
 
 @Validated
 @RestController
@@ -42,7 +40,7 @@ public class ReviewController {
         ));
 	}
     @GetMapping("/albums/{albumId}")
-	public BaseResponse<PageResponse<AlbumReviewResponse>> getAlbumReviews(
+	public BaseResponse<OffsetPageResponse<AlbumReviewResponse>> getAlbumReviews(
 		@PathVariable(name = "albumId") String albumId,
         @Range(min = 0, max = 1000, message = "offset은 0에서 1000사이의 값 이어야 합니다.") @RequestParam("offset") int offset,
         @Range(min = 0, max = 50, message = "limit은 0에서 50사이의 값 이어야 합니다.") @RequestParam("limit") int limit,
@@ -52,7 +50,7 @@ public class ReviewController {
 	}
 
     @GetMapping("/albums/me")
-    public BaseResponse<PageResponse<MyAlbumReviewResponse>> getMyAlbumReview(
+    public BaseResponse<OffsetPageResponse<MyAlbumReviewResponse>> getMyAlbumReview(
         @Range(min = 0, max = 1000, message = "offset은 0에서 1000사이의 값 이어야 합니다.") @RequestParam("offset") int offset,
         @Range(min = 0, max = 50, message = "limit은 0에서 50사이의 값 이어야 합니다.") @RequestParam("limit") int limit,
         @RequestParam(name = "sort") @ValidEnum(enumClass = ReviewSort.class) String sort

--- a/src/main/java/com/project/singk/domain/review/controller/port/ReviewService.java
+++ b/src/main/java/com/project/singk/domain/review/controller/port/ReviewService.java
@@ -4,15 +4,13 @@ import com.project.singk.domain.review.controller.response.AlbumReviewResponse;
 import com.project.singk.domain.review.controller.response.AlbumReviewStatisticsResponse;
 import com.project.singk.domain.review.controller.response.MyAlbumReviewResponse;
 import com.project.singk.domain.review.domain.AlbumReviewCreate;
-import com.project.singk.global.api.PageResponse;
+import com.project.singk.global.api.OffsetPageResponse;
 import com.project.singk.global.domain.PkResponseDto;
-
-import java.util.List;
 
 public interface ReviewService {
     PkResponseDto createAlbumReview(Long memberId, String albumId, AlbumReviewCreate albumReviewCreate);
     void deleteAlbumReview(Long memberId, String albumId, Long albumReviewId);
-    PageResponse<AlbumReviewResponse> getAlbumReviews(String albumId, int offset, int limit, String sort);
+    OffsetPageResponse<AlbumReviewResponse> getAlbumReviews(String albumId, int offset, int limit, String sort);
     AlbumReviewStatisticsResponse getAlbumReviewStatistics(String albumId);
-    PageResponse<MyAlbumReviewResponse> getMyAlbumReview(Long memberId, int offset, int limit, String sort);
+    OffsetPageResponse<MyAlbumReviewResponse> getMyAlbumReview(Long memberId, int offset, int limit, String sort);
 }

--- a/src/main/java/com/project/singk/domain/review/controller/response/AlbumReviewStatisticsSimpleResponse.java
+++ b/src/main/java/com/project/singk/domain/review/controller/response/AlbumReviewStatisticsSimpleResponse.java
@@ -1,0 +1,23 @@
+package com.project.singk.domain.review.controller.response;
+
+import com.project.singk.domain.review.domain.AlbumReviewStatistics;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+public class AlbumReviewStatisticsSimpleResponse {
+    private Long id;
+    private long count;
+    private double averageScore;
+
+    public static AlbumReviewStatisticsSimpleResponse from(AlbumReviewStatistics statistics) {
+        return AlbumReviewStatisticsSimpleResponse.builder()
+                .id(statistics.getId())
+                .count(statistics.getTotalReviewer())
+                .averageScore(statistics.calculateAverage(statistics.getTotalScore(), statistics.getTotalReviewer()))
+                .build();
+    }
+}

--- a/src/main/java/com/project/singk/domain/review/infrastructure/AlbumReviewStatisticsEntity.java
+++ b/src/main/java/com/project/singk/domain/review/infrastructure/AlbumReviewStatisticsEntity.java
@@ -10,11 +10,14 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
 @Entity
-@Table(name = "ALBUM_REVIEW_STATISTICS", indexes = {
-        @Index(name = "idx_album_statistic_modified_at", columnList = "modifiedAt DESC"),
-        @Index(name = "idx_album_statistic_total_reviewer", columnList = "totalReviewer DESC"),
-        @Index(name = "idx_album_statistic_average_score", columnList = "averageScore DESC")
-})
+@Table(
+        name = "ALBUM_REVIEW_STATISTICS",
+        indexes = {
+            @Index(name = "idx_album_statistic_modified_at", columnList = "modifiedAt DESC"),
+            @Index(name = "idx_album_statistic_total_reviewer", columnList = "totalReviewer DESC"),
+            @Index(name = "idx_album_statistic_average_score", columnList = "averageScore DESC")
+        }
+)
 @Getter
 @NoArgsConstructor
 public class AlbumReviewStatisticsEntity extends BaseTimeEntity {

--- a/src/main/java/com/project/singk/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/project/singk/domain/review/service/ReviewServiceImpl.java
@@ -10,7 +10,6 @@ import com.project.singk.domain.member.domain.Member;
 import com.project.singk.domain.member.domain.MemberStatistics;
 import com.project.singk.domain.member.service.port.MemberRepository;
 import com.project.singk.domain.review.controller.port.ReviewService;
-import com.project.singk.domain.review.controller.request.ReviewSort;
 import com.project.singk.domain.review.controller.response.AlbumReviewResponse;
 import com.project.singk.domain.review.controller.response.AlbumReviewStatisticsResponse;
 import com.project.singk.domain.review.controller.response.MyAlbumReviewResponse;
@@ -19,7 +18,7 @@ import com.project.singk.domain.review.domain.AlbumReviewStatistics;
 import com.project.singk.domain.review.service.port.AlbumReviewRepository;
 import com.project.singk.global.api.ApiException;
 import com.project.singk.global.api.AppHttpStatus;
-import com.project.singk.global.api.PageResponse;
+import com.project.singk.global.api.OffsetPageResponse;
 import lombok.Builder;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -29,8 +28,6 @@ import com.project.singk.domain.review.domain.AlbumReviewCreate;
 import com.project.singk.global.domain.PkResponseDto;
 
 import lombok.RequiredArgsConstructor;
-
-import java.util.List;
 
 @Service
 @Builder
@@ -108,10 +105,10 @@ public class ReviewServiceImpl implements ReviewService {
 
     @Override
     @Transactional(readOnly = true)
-    public PageResponse<AlbumReviewResponse> getAlbumReviews(String albumId, int offset, int limit, String sort) {
+    public OffsetPageResponse<AlbumReviewResponse> getAlbumReviews(String albumId, int offset, int limit, String sort) {
         Page<AlbumReview> reviews = albumReviewRepository.getAllByAlbumId(albumId, offset, limit, sort);
 
-        return PageResponse.of(
+        return OffsetPageResponse.of(
                 offset,
                 limit,
                 (int) reviews.getTotalElements(),
@@ -132,9 +129,9 @@ public class ReviewServiceImpl implements ReviewService {
 
     @Override
     @Transactional(readOnly = true)
-    public PageResponse<MyAlbumReviewResponse> getMyAlbumReview(Long memberId, int offset, int limit, String sort) {
+    public OffsetPageResponse<MyAlbumReviewResponse> getMyAlbumReview(Long memberId, int offset, int limit, String sort) {
         Page<AlbumReview> reviews = albumReviewRepository.getAllByMemberId(memberId, offset, limit, sort);
-        return PageResponse.of(
+        return OffsetPageResponse.of(
                 offset,
                 limit,
                 (int) reviews.getTotalElements(),

--- a/src/main/java/com/project/singk/global/api/CursorPageResponse.java
+++ b/src/main/java/com/project/singk/global/api/CursorPageResponse.java
@@ -1,0 +1,41 @@
+package com.project.singk.global.api;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CursorPageResponse<T> {
+
+	private int limit;
+    private boolean hasNext;
+	private List<T> items;
+
+    public static <T> CursorPageResponse<T> of (int limit, boolean hasNext, List<T> items) {
+		return CursorPageResponse.<T>builder()
+			.limit(limit)
+            .hasNext(hasNext)
+			.items(items)
+			.build();
+	}
+
+    public <R> CursorPageResponse<R> map(Function<? super T, ? extends R> converter) {
+        List<R> newItems = this.items.stream()
+                .map(converter)
+                .collect(Collectors.toList());
+        return CursorPageResponse.<R>builder()
+                .limit(this.limit)
+                .hasNext(this.hasNext)
+                .items(newItems)
+                .build();
+    }
+}

--- a/src/main/java/com/project/singk/global/api/OffsetPageResponse.java
+++ b/src/main/java/com/project/singk/global/api/OffsetPageResponse.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class PageResponse<T> {
+public class OffsetPageResponse<T> {
 
     // 기본 값일 때 응답에 미포함
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
@@ -23,8 +23,8 @@ public class PageResponse<T> {
 	private int total;
 	private List<T> items;
 
-	public static <T> PageResponse<T> of (int offset, int limit, int total, List<T> items) {
-		return PageResponse.<T>builder()
+	public static <T> OffsetPageResponse<T> of (int offset, int limit, int total, List<T> items) {
+		return OffsetPageResponse.<T>builder()
 			.offset(offset)
 			.limit(limit)
 			.total(total)
@@ -32,19 +32,11 @@ public class PageResponse<T> {
 			.build();
 	}
 
-    public static <T> PageResponse<T> of (int limit, int total, List<T> items) {
-		return PageResponse.<T>builder()
-			.limit(limit)
-			.total(total)
-			.items(items)
-			.build();
-	}
-
-    public <R> PageResponse<R> map(Function<? super T, ? extends R> converter) {
+    public <R> OffsetPageResponse<R> map(Function<? super T, ? extends R> converter) {
         List<R> newItems = this.items.stream()
                 .map(converter)
                 .collect(Collectors.toList());
-        return PageResponse.<R>builder()
+        return OffsetPageResponse.<R>builder()
                 .offset(this.offset)
                 .limit(this.limit)
                 .total(this.total)

--- a/src/main/java/com/project/singk/global/api/OffsetPageResponse.java
+++ b/src/main/java/com/project/singk/global/api/OffsetPageResponse.java
@@ -16,8 +16,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class OffsetPageResponse<T> {
 
-    // 기본 값일 때 응답에 미포함
-    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 	private int offset;
 	private int limit;
 	private int total;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,7 +13,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        # default_batch_fetch_size: 1000
+        default_batch_fetch_size: 100
       dialect: org.hibernate.dialect.MySQL8InnoDBDialect
     # defer-datasource-initialization: true
   data:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,7 +13,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        default_batch_fetch_size: 1000
+        # default_batch_fetch_size: 1000
       dialect: org.hibernate.dialect.MySQL8InnoDBDialect
     # defer-datasource-initialization: true
   data:

--- a/src/test/java/com/project/singk/domain/album/service/AlbumServiceTest.java
+++ b/src/test/java/com/project/singk/domain/album/service/AlbumServiceTest.java
@@ -5,9 +5,8 @@ import com.project.singk.domain.album.controller.response.AlbumListResponse;
 import com.project.singk.domain.album.domain.*;
 import com.project.singk.domain.album.infrastructure.spotify.AlbumEntity;
 import com.project.singk.domain.review.domain.AlbumReviewStatistics;
-import com.project.singk.global.api.PageResponse;
+import com.project.singk.global.api.OffsetPageResponse;
 import com.project.singk.mock.TestContainer;
-import org.checkerframework.checker.units.qual.A;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
@@ -126,7 +125,7 @@ class AlbumServiceTest {
         TestContainer testContainer = TestContainer.builder().build();
 
         // when
-        PageResponse<AlbumListResponse> response = testContainer.albumService.searchAlbums("query", 0, 20);
+        OffsetPageResponse<AlbumListResponse> response = testContainer.albumService.searchAlbums("query", 0, 20);
 
         // then
         assertAll(
@@ -168,7 +167,7 @@ class AlbumServiceTest {
         int limit = 5;
 
         // when
-        PageResponse<AlbumListResponse> response = testContainer.albumService.getAlbumsByDate(cursorId, cursorDate, limit);
+        OffsetPageResponse<AlbumListResponse> response = testContainer.albumService.getAlbumsByDate(cursorId, cursorDate, limit);
 
         // then
         assertAll(
@@ -211,7 +210,7 @@ class AlbumServiceTest {
         int limit = 5;
 
         // when
-        PageResponse<AlbumListResponse> response = testContainer.albumService.getAlbumsByDate(cursorId, cursorDate, limit);
+        OffsetPageResponse<AlbumListResponse> response = testContainer.albumService.getAlbumsByDate(cursorId, cursorDate, limit);
 
         // then
         assertAll(
@@ -260,7 +259,7 @@ class AlbumServiceTest {
         int limit = 5;
 
         // when
-        PageResponse<AlbumListResponse> response = testContainer.albumService.getAlbumsByAverageScore(cursorId, cursorScore, limit);
+        OffsetPageResponse<AlbumListResponse> response = testContainer.albumService.getAlbumsByAverageScore(cursorId, cursorScore, limit);
 
         // then
         assertAll(
@@ -309,7 +308,7 @@ class AlbumServiceTest {
         int limit = 5;
 
         // when
-        PageResponse<AlbumListResponse> response = testContainer.albumService.getAlbumsByAverageScore(cursorId, cursorScore, limit);
+        OffsetPageResponse<AlbumListResponse> response = testContainer.albumService.getAlbumsByAverageScore(cursorId, cursorScore, limit);
 
         // then
         assertAll(
@@ -352,7 +351,7 @@ class AlbumServiceTest {
         int limit = 5;
 
         // when
-        PageResponse<AlbumListResponse> response = testContainer.albumService.getAlbumsByReviewCount(cursorId, cursorReviewCount, limit);
+        OffsetPageResponse<AlbumListResponse> response = testContainer.albumService.getAlbumsByReviewCount(cursorId, cursorReviewCount, limit);
 
         // then
         assertAll(
@@ -395,7 +394,7 @@ class AlbumServiceTest {
         int limit = 5;
 
         // when
-        PageResponse<AlbumListResponse> response = testContainer.albumService.getAlbumsByReviewCount(cursorId, cursorReviewCount, limit);
+        OffsetPageResponse<AlbumListResponse> response = testContainer.albumService.getAlbumsByReviewCount(cursorId, cursorReviewCount, limit);
 
         // then
         assertAll(

--- a/src/test/java/com/project/singk/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/project/singk/domain/review/service/ReviewServiceTest.java
@@ -14,7 +14,7 @@ import com.project.singk.domain.review.domain.AlbumReviewCreate;
 import com.project.singk.domain.review.domain.AlbumReviewStatistics;
 import com.project.singk.global.api.ApiException;
 import com.project.singk.global.api.AppHttpStatus;
-import com.project.singk.global.api.PageResponse;
+import com.project.singk.global.api.OffsetPageResponse;
 import com.project.singk.global.domain.PkResponseDto;
 import com.project.singk.mock.TestContainer;
 import org.junit.jupiter.api.BeforeEach;
@@ -167,7 +167,7 @@ class ReviewServiceTest {
         albumReviews = tc.albumReviewRepository.saveAll(albumReviews);
 
         // when
-        PageResponse<AlbumReviewResponse> result = tc.reviewService.getAlbumReviews("0EhZEM4RRz0yioTgucDhJq", 0, 5,"NEW");
+        OffsetPageResponse<AlbumReviewResponse> result = tc.reviewService.getAlbumReviews("0EhZEM4RRz0yioTgucDhJq", 0, 5,"NEW");
 
         // then
         assertAll(
@@ -212,7 +212,7 @@ class ReviewServiceTest {
         albumReviews = tc.albumReviewRepository.saveAll(albumReviews);
 
         // when
-        PageResponse<AlbumReviewResponse> result = tc.reviewService.getAlbumReviews("0EhZEM4RRz0yioTgucDhJq",0, 5, "LIKES");
+        OffsetPageResponse<AlbumReviewResponse> result = tc.reviewService.getAlbumReviews("0EhZEM4RRz0yioTgucDhJq",0, 5, "LIKES");
 
         // then
         assertAll(
@@ -301,7 +301,7 @@ class ReviewServiceTest {
         albumReviews = tc.albumReviewRepository.saveAll(albumReviews);
 
         // when
-        PageResponse<MyAlbumReviewResponse> result = tc.reviewService.getMyAlbumReview(1L, 0, 5,"NEW");
+        OffsetPageResponse<MyAlbumReviewResponse> result = tc.reviewService.getMyAlbumReview(1L, 0, 5,"NEW");
 
         // then
         assertAll(
@@ -357,7 +357,7 @@ class ReviewServiceTest {
         albumReviews = tc.albumReviewRepository.saveAll(albumReviews);
 
         // when
-        PageResponse<MyAlbumReviewResponse> result = tc.reviewService.getMyAlbumReview(1L, 0, 5,"LIKES");
+        OffsetPageResponse<MyAlbumReviewResponse> result = tc.reviewService.getMyAlbumReview(1L, 0, 5,"LIKES");
 
         // then
         assertAll(

--- a/src/test/java/com/project/singk/mock/FakeSpotifyRepository.java
+++ b/src/test/java/com/project/singk/mock/FakeSpotifyRepository.java
@@ -3,7 +3,7 @@ package com.project.singk.mock;
 import com.project.singk.domain.album.infrastructure.spotify.*;
 import com.project.singk.domain.album.service.port.SpotifyRepository;
 
-import com.project.singk.global.api.PageResponse;
+import com.project.singk.global.api.OffsetPageResponse;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -55,7 +55,7 @@ public class FakeSpotifyRepository implements SpotifyRepository {
     }
 
     @Override
-    public PageResponse<AlbumSimplifiedEntity> searchAlbums(String query, int offset, int limit) {
+    public OffsetPageResponse<AlbumSimplifiedEntity> searchAlbums(String query, int offset, int limit) {
         List<ArtistSimplifiedEntity> artists = List.of(
                 ArtistSimplifiedEntity.builder()
                         .id("6HvZYsbFfjnjFrWF950C9d")
@@ -78,7 +78,7 @@ public class FakeSpotifyRepository implements SpotifyRepository {
                         .images(images)
                         .build()
         );
-        return PageResponse.of(
+        return OffsetPageResponse.of(
                 offset,
                 limit,
                 albums.size(),


### PR DESCRIPTION
## 구현 내용
- 최근 평가된/평점 높은순/평가 높은순 앨범 목록 조회 API에 대한 성능 개선
- Album -> AlbumSimplified로 필요한 엔티티만 조회
- 커서 페이지네이션 전용 응답 생성